### PR TITLE
SCA-18 Added Icon Mappings for Agenda and Time/Location

### DIFF
--- a/SORM Symposium/components/ui/IconSymbol.tsx
+++ b/SORM Symposium/components/ui/IconSymbol.tsx
@@ -1,11 +1,14 @@
 // Fallback for using MaterialIcons on Android and web.
 
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
-import { ComponentProps } from 'react';
-import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { SymbolWeight, SymbolViewProps } from "expo-symbols";
+import { ComponentProps } from "react";
+import { OpaqueColorValue, type StyleProp, type TextStyle } from "react-native";
 
-type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
+type IconMapping = Record<
+  SymbolViewProps["name"],
+  ComponentProps<typeof MaterialIcons>["name"]
+>;
 type IconSymbolName = keyof typeof MAPPING;
 
 /**
@@ -14,8 +17,12 @@ type IconSymbolName = keyof typeof MAPPING;
  * - see SF Symbols in the [SF Symbols](https://developer.apple.com/sf-symbols/) app.
  */
 const MAPPING = {
-  'house.fill': 'home',
-  'person.fill': 'person',
+  "house.fill": "home",
+  "person.fill": "person",
+  calendar: "calendar-today",
+  "clock.fill": "access-time",
+  "mappin.circle.fill": "location-on",
+  "chevron.right": "chevron-right",
 } as IconMapping;
 
 /**
@@ -35,5 +42,12 @@ export function IconSymbol({
   style?: StyleProp<TextStyle>;
   weight?: SymbolWeight;
 }) {
-  return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;
+  return (
+    <MaterialIcons
+      color={color}
+      size={size}
+      name={MAPPING[name]}
+      style={style}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
Fixes issue with some icons not appearing on Web and Android devices.

## Screenshots
![image](https://github.com/user-attachments/assets/c1e90005-1d9a-4604-b73a-05858afef82b)
