### PR TITLE
sca-34: implement login

### DIFF
--- a/SORM Symposium/api/signinUser.ts
+++ b/SORM Symposium/api/signinUser.ts
@@ -1,0 +1,20 @@
+import { supabase } from "@/constants/supabase";
+
+/**
+ * Sign in a user.
+ * @param email The user's email.
+ * @param password The user's password.
+ * @returns The user object returned by Supabase.
+ */
+export default async function signinUser(email: string, password: string) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password
+  });
+  
+  if (error) {
+    throw error;
+  }
+  
+  return data;
+}

--- a/SORM Symposium/app/login.tsx
+++ b/SORM Symposium/app/login.tsx
@@ -1,9 +1,10 @@
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
-import { Button, StyleSheet } from "react-native";
+import { Alert, Button, StyleSheet } from "react-native";
 import { router } from "expo-router";
 import { useState } from "react";
 import ThemedTextInput from "@/components/ThemedTextInput";
+import signinUser from "@/api/signinUser";
 
 export default function Login() {
   const [showLoginScreen, setShowLoginScreen] = useState<boolean>(false);
@@ -14,6 +15,7 @@ export default function Login() {
     email: "",
     password: "",
   });
+  const [err, setErr] = useState<string>("");
   const validEmail = /^[A-Za-z0-9]+@[A-Za-z0-9-]+\.[A-Za-z]{2,}$/.test(
     login.email,
   );
@@ -23,6 +25,17 @@ export default function Login() {
       ...prev,
       [field]: value,
     }));
+  };
+
+  const handleLogin = async () => {
+    const { email, password } = login;
+    setErr("");
+    try {
+      await signinUser(email, password);
+      router.push("/");
+    } catch (e) {
+      setErr("Failed to login: " + (e as Error).message);
+    }
   };
 
   const navigate = (type: "attendee" | "organizer") => {
@@ -81,8 +94,13 @@ export default function Login() {
         />
       </ThemedView>
 
-      <Button title="Sign In" disabled={!validEmail} />
+      <Button
+        title="Sign In"
+        onPress={handleLogin}
+        disabled={!validEmail || login.password.length === 0}
+      />
       <Button title="Back" onPress={() => setShowLoginScreen(false)} />
+      <ThemedText style={styles.invalid}>{err}</ThemedText>
     </ThemedView>
   );
 }


### PR DESCRIPTION
**Note: commit says sca-33 but it should be sca-34.**

Implements the login functionality to authenticate a user that exists in the currently available users in the [Authentication tab](https://supabase.com/dashboard/project/izlxjqgiauljmlqtzrto/auth/users). Note that I've added all the planning organizers as users, but it would be a good idea to test on the test account I've made.
I've also disabled the need of having to confirm emails as the planning organizers likely will not have to do that (additionally, they would not be able to authenticate themselves in the app until the email is confirmed, so it would be a major block.)
I've also [disabled signups](https://supabase.com/dashboard/project/izlxjqgiauljmlqtzrto/auth/providers), as there will be no need to sign up from the app itself. If we do need to add more users, then it can be done by creating a user from the drop down menu available in the list of users.

Also, the password for all the accounts is a PIN (1234). Im cant remember if that's what we want, but I've added it there for now.