### PR TITLE
Sca 36 update expo token

### DIFF
--- a/SORM Symposium/api/saveExpoPushToken.ts
+++ b/SORM Symposium/api/saveExpoPushToken.ts
@@ -7,11 +7,15 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
  * @param deviceId The ID associated with the device.
  */
 export default async function saveExpoPushToken(tok: string, deviceId: string) {
-  const createdToken = await AsyncStorage.getItem("created-expo-token");
+  try {
+    const createdToken = await AsyncStorage.getItem("created-expo-token");
 
-  if (createdToken === "true") {
-    // No need to create another request.
-    return;
+    if (createdToken === "true") {
+      // No need to create another request.
+      return;
+    }
+  } catch (_) {
+    console.error("Couldn't verify if expo token was created before...");
   }
 
   const { error: insertError } = await supabase.from("test_profiles").upsert({

--- a/SORM Symposium/api/saveExpoPushToken.ts
+++ b/SORM Symposium/api/saveExpoPushToken.ts
@@ -9,7 +9,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 export default async function saveExpoPushToken(tok: string, deviceId: string) {
   const createdToken = await AsyncStorage.getItem("created-expo-token");
 
-  if (createdToken) {
+  if (createdToken === "true") {
     // No need to create another request.
     return;
   }

--- a/SORM Symposium/api/saveExpoPushToken.ts
+++ b/SORM Symposium/api/saveExpoPushToken.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/constants/supabase";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 /**
  * Saves the Expo Push Token to the database.
@@ -6,26 +7,19 @@ import { supabase } from "@/constants/supabase";
  * @param deviceId The ID associated with the device.
  */
 export default async function saveExpoPushToken(tok: string, deviceId: string) {
-  // Check if the token exists first
-  const { data: existingToken, error } = await supabase
-    .from("test_profiles")
-    .select("expo_push_token")
-    .eq("id", deviceId)
-    .single();
+  const createdToken = await AsyncStorage.getItem("created-expo-token");
 
-  // PGRST116 means that the row does not exist.
-  if (error && error.code !== "PGRST116") {
-    throw error;
+  if (createdToken) {
+    // No need to create another request.
+    return;
   }
 
-  if (!existingToken) {
-    const { error: insertError } = await supabase.from("test_profiles").upsert({
-      id: deviceId,
-      expo_push_token: tok,
-    });
+  const { error: insertError } = await supabase.from("test_profiles").upsert({
+    id: deviceId,
+    expo_push_token: tok,
+  });
 
-    if (insertError) {
-      throw insertError;
-    }
+  if (insertError) {
+    throw insertError;
   }
 }

--- a/SORM Symposium/components/ExpoPushTokenProvider.tsx
+++ b/SORM Symposium/components/ExpoPushTokenProvider.tsx
@@ -6,6 +6,7 @@ import * as Application from "expo-application";
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 import saveExpoPushToken from "@/api/saveExpoPushToken";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const ExpoPushTokenContext = createContext<string | null>(null);
 
@@ -79,6 +80,8 @@ function ExpoPushTokenProvider({ children }: ExpoPushTokenProviderProps) {
       setToken(token);
 
       await saveExpoPushToken(token, deviceId);
+      
+      await AsyncStorage.setItem('created-expo-token', 'true');
     }
 
     const notificationListener = Notifications.addNotificationReceivedListener(

--- a/SORM Symposium/components/ExpoPushTokenProvider.tsx
+++ b/SORM Symposium/components/ExpoPushTokenProvider.tsx
@@ -80,8 +80,12 @@ function ExpoPushTokenProvider({ children }: ExpoPushTokenProviderProps) {
       setToken(token);
 
       await saveExpoPushToken(token, deviceId);
-      
-      await AsyncStorage.setItem('created-expo-token', 'true');
+
+      try {
+        await AsyncStorage.setItem("created-expo-token", "true");
+      } catch (e) {
+        console.error("Failed to set `created-expo-token` in storage...");
+      }
     }
 
     const notificationListener = Notifications.addNotificationReceivedListener(

--- a/SORM Symposium/package-lock.json
+++ b/SORM Symposium/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2764,6 +2765,17 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
+      "integrity": "sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -7869,6 +7881,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8851,6 +8871,17 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/SORM Symposium/package.json
+++ b/SORM Symposium/package.json
@@ -41,7 +41,8 @@
     "expo-notifications": "~0.31.2",
     "expo-device": "~7.1.4",
     "expo-dev-client": "~5.1.8",
-    "expo-application": "~6.1.4"
+    "expo-application": "~6.1.4",
+    "@react-native-async-storage/async-storage": "2.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Fixes the issue where if a user uninstalls the app and re-installs, they will not be able to receive push notifications despite enabling to have them. This is because when the user first installs the app, their first push token is sent to the database. However, the old implementation had checks where if there was an existing token, the app would not update the database again. This edge case slipped by as whenever a user uninstalled the app and re-installed it, a new push token would be created and the old token would be invalid. However, the new token would not be updated in the database due to the old implementation.

Now, whenever a user opens the app for the first time, the new token will be updated in the database. 