### PR TITLE
Sca 32 hide admin tab

### DIFF
--- a/SORM Symposium/app/(tabs)/_layout.tsx
+++ b/SORM Symposium/app/(tabs)/_layout.tsx
@@ -6,13 +6,17 @@ import { useColorScheme } from "react-native";
 import { Colors } from "@/constants/Colors";
 import { HapticTab } from "@/components/HapticTab";
 import TabBarBackground from "@/components/ui/TabBarBackground";
+import useSupabaseAuth from "@/hooks/useSupabaseAuth";
 
 export default function TabLayout() {
+  const user = useSupabaseAuth();
+
   return (
     <Tabs
       initialRouteName="index"
       screenOptions={{
-        tabBarActiveTintColor: Colors[useColorScheme() ?? "light"].tabIconSelected,
+        tabBarActiveTintColor:
+          Colors[useColorScheme() ?? "light"].tabIconSelected,
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
@@ -54,6 +58,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="admin"
         options={{
+          href: user ? "/(tabs)/admin" : null,
           title: "Admin",
           tabBarIcon: ({ color }) => (
             <IconSymbol name="person.fill" color={color} size={28} />

--- a/SORM Symposium/app/(tabs)/admin.tsx
+++ b/SORM Symposium/app/(tabs)/admin.tsx
@@ -2,13 +2,16 @@ import AnnouncementForm from "@/components/AnnouncementForm";
 import { ThemedText } from "@/components/ThemedText";
 import ThemedTextInput from "@/components/ThemedTextInput";
 import { ThemedView } from "@/components/ThemedView";
+import useSupabaseAuth from "@/hooks/useSupabaseAuth";
 import { useState } from "react";
 import { Button, SafeAreaView } from "react-native";
+import { Redirect } from "expo-router";
 
 const TEMPORARY_PIN = "1234";
 
 export default function Admin() {
   const [pin, setPin] = useState<string>("");
+  const user = useSupabaseAuth();
 
   function handlePinChange(text: string) {
     setPin(text);
@@ -16,6 +19,10 @@ export default function Admin() {
 
   function resetPin() {
     setPin("");
+  }
+
+  if (!user) {
+    return <Redirect href="/(tabs)/agenda" />;
   }
 
   if (pin === TEMPORARY_PIN) {

--- a/SORM Symposium/app/_layout.tsx
+++ b/SORM Symposium/app/_layout.tsx
@@ -13,6 +13,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { enableScreens } from "react-native-screens";
 import { Platform } from "react-native";
 import { ExpoPushTokenProvider } from "@/components/ExpoPushTokenProvider";
+import { AuthSessionProvider } from "@/components/AuthSessionProvider";
 
 // Enable screens for better performance
 enableScreens();
@@ -33,18 +34,20 @@ export default function RootLayout() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
         <ExpoPushTokenProvider>
-          <Stack
-            screenOptions={{
-              contentStyle: {
-                paddingTop: topInset,
-              },
-            }}
-          >
-            <Stack.Screen name="login" options={{ headerShown: false }} />
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen name="+not-found" />
-          </Stack>
-          <StatusBar style="auto" />
+          <AuthSessionProvider>
+            <Stack
+              screenOptions={{
+                contentStyle: {
+                  paddingTop: topInset,
+                },
+              }}
+            >
+              <Stack.Screen name="login" options={{ headerShown: false }} />
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+            <StatusBar style="auto" />
+          </AuthSessionProvider>
         </ExpoPushTokenProvider>
       </ThemeProvider>
     </GestureHandlerRootView>

--- a/SORM Symposium/components/AuthSessionProvider.tsx
+++ b/SORM Symposium/components/AuthSessionProvider.tsx
@@ -1,0 +1,29 @@
+import { supabase } from "@/constants/supabase";
+import { Session } from "@supabase/supabase-js";
+import { ReactNode, useEffect, useState, createContext } from "react"
+
+const AuthSessionContext = createContext<Session | null | undefined>(undefined);
+
+type AuthSessionProviderProps = {
+  children: ReactNode;
+};
+
+function AuthSessionProvider({ children }: AuthSessionProviderProps) {
+  const [session, setSession] = useState<Session | null>(null);
+  
+  useEffect(() => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => {
+      setSession(session);
+    });
+    
+    return subscription.unsubscribe;
+  }, []);
+  
+  return (
+    <AuthSessionContext.Provider value={session}>
+      {children}
+    </AuthSessionContext.Provider>
+  )
+}
+
+export { AuthSessionContext, AuthSessionProvider };

--- a/SORM Symposium/hooks/useSupabaseAuth.ts
+++ b/SORM Symposium/hooks/useSupabaseAuth.ts
@@ -1,0 +1,20 @@
+import { AuthSessionContext } from "@/components/AuthSessionProvider";
+import { useContext } from "react";
+
+/**
+ * Get the current user session.
+ * @returns the Session object returned by Supabase, if there is a user session.
+ */
+function useSupabaseAuth() {
+  const context = useContext(AuthSessionContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useSupabaseAuth must be used within an AuthSessionProvider."
+    );
+  }
+
+  return context;
+}
+
+export default useSupabaseAuth;


### PR DESCRIPTION
This PR implements the changes needed to hide the admin tab if not logged in. This works by subscribing to auth events via [`onAuthStateChange`](https://supabase.com/docs/reference/javascript/auth-onauthstatechange), which contain a session object if the user is considered logged in. This object is then passed via React Context to be accessible anywhere via [`useSupabaseAuth`](https://github.com/sorm-conference-app/conference-app/blob/d55ba235e56cb6d6bdadd987c26c330b6d1f2ca1/SORM%20Symposium/hooks/useSupabaseAuth.ts).