### PR TITLE
Sca 28 add and delete events

### DIFF
--- a/SORM Symposium/api/signinUser.ts
+++ b/SORM Symposium/api/signinUser.ts
@@ -1,0 +1,20 @@
+import { supabase } from "@/constants/supabase";
+
+/**
+ * Sign in a user.
+ * @param email The user's email.
+ * @param password The user's password.
+ * @returns The user object returned by Supabase.
+ */
+export default async function signinUser(email: string, password: string) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password
+  });
+  
+  if (error) {
+    throw error;
+  }
+  
+  return data;
+}

--- a/SORM Symposium/app/(tabs)/_layout.tsx
+++ b/SORM Symposium/app/(tabs)/_layout.tsx
@@ -6,13 +6,17 @@ import { useColorScheme } from "react-native";
 import { Colors } from "@/constants/Colors";
 import { HapticTab } from "@/components/HapticTab";
 import TabBarBackground from "@/components/ui/TabBarBackground";
+import useSupabaseAuth from "@/hooks/useSupabaseAuth";
 
 export default function TabLayout() {
+  const user = useSupabaseAuth();
+
   return (
     <Tabs
       initialRouteName="index"
       screenOptions={{
-        tabBarActiveTintColor: Colors[useColorScheme() ?? "light"].tabIconSelected,
+        tabBarActiveTintColor:
+          Colors[useColorScheme() ?? "light"].tabIconSelected,
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
@@ -54,6 +58,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="admin"
         options={{
+          href: user ? "/(tabs)/admin" : null,
           title: "Admin",
           tabBarIcon: ({ color }) => (
             <IconSymbol name="person.fill" color={color} size={28} />

--- a/SORM Symposium/app/(tabs)/admin.tsx
+++ b/SORM Symposium/app/(tabs)/admin.tsx
@@ -3,6 +3,10 @@ import { AgendaEditor } from "@/components/AgendaViewer/AgendaEditor";
 import { ThemedText } from "@/components/ThemedText";
 import ThemedTextInput from "@/components/ThemedTextInput";
 import { ThemedView } from "@/components/ThemedView";
+import useSupabaseAuth from "@/hooks/useSupabaseAuth";
+import { useState } from "react";
+import { Button, SafeAreaView } from "react-native";
+import { Redirect } from "expo-router";
 import { useState, useRef } from "react";
 import { Button, SafeAreaView, ScrollView, StyleSheet, ViewStyle, View } from "react-native";
 
@@ -10,6 +14,7 @@ const TEMPORARY_PIN = "1234";
 
 export default function Admin() {
   const [pin, setPin] = useState<string>("");
+  const user = useSupabaseAuth();
   const scrollViewRef = useRef<ScrollView>(null);
   const agendaEditorRef = useRef<View>(null);
 
@@ -19,6 +24,10 @@ export default function Admin() {
 
   function resetPin() {
     setPin("");
+  }
+
+  if (!user) {
+    return <Redirect href="/(tabs)/agenda" />;
   }
 
   const scrollToAgendaEditor = () => {

--- a/SORM Symposium/app/(tabs)/admin.tsx
+++ b/SORM Symposium/app/(tabs)/admin.tsx
@@ -4,8 +4,6 @@ import { ThemedText } from "@/components/ThemedText";
 import ThemedTextInput from "@/components/ThemedTextInput";
 import { ThemedView } from "@/components/ThemedView";
 import useSupabaseAuth from "@/hooks/useSupabaseAuth";
-import { useState } from "react";
-import { Button, SafeAreaView } from "react-native";
 import { Redirect } from "expo-router";
 import { useState, useRef } from "react";
 import { Button, SafeAreaView, ScrollView, StyleSheet, ViewStyle, View } from "react-native";

--- a/SORM Symposium/app/(tabs)/agenda.tsx
+++ b/SORM Symposium/app/(tabs)/agenda.tsx
@@ -25,7 +25,7 @@ export default function AgendaScreen() {
         onSelectEvent={navigateToEvent} 
         onEventPosition={() => {}} // No use for event postions in this screen
         showHeader={true} 
-        showDeleted={false}
+        showDeleted={'active'} // Default to showing only active events
         reloadTrigger={1} // Reload trigger not used on this screen
       />
     </ThemedView>

--- a/SORM Symposium/app/(tabs)/agenda.tsx
+++ b/SORM Symposium/app/(tabs)/agenda.tsx
@@ -25,6 +25,7 @@ export default function AgendaScreen() {
         onSelectEvent={navigateToEvent} 
         onEventPosition={() => {}} // No use for event postions in this screen
         showHeader={true} 
+        showDeleted={false}
         reloadTrigger={1} // Reload trigger not used on this screen
       />
     </ThemedView>

--- a/SORM Symposium/app/_layout.tsx
+++ b/SORM Symposium/app/_layout.tsx
@@ -1,20 +1,25 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
-import { StatusBar } from 'expo-status-bar';
-import 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useColorScheme } from '@/hooks/useColorScheme';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { enableScreens } from 'react-native-screens';
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { useFonts } from "expo-font";
+import { Stack } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { enableScreens } from "react-native-screens";
 import { Platform } from "react-native";
 import { ExpoPushTokenProvider } from "@/components/ExpoPushTokenProvider";
+import { AuthSessionProvider } from "@/components/AuthSessionProvider";
 
 // Enable screens for better performance
 enableScreens();
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme() ?? 'light';
+  const colorScheme = useColorScheme() ?? "light";
   const [loaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
@@ -27,21 +32,24 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-      <ExpoPushTokenProvider>
-        <Stack
-          screenOptions={{
-            contentStyle: {
-              paddingTop: topInset,
-            },
-          }}
-        >
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </ExpoPushTokenProvider>
-    </ThemeProvider>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <ExpoPushTokenProvider>
+          <AuthSessionProvider>
+            <Stack
+              screenOptions={{
+                contentStyle: {
+                  paddingTop: topInset,
+                },
+              }}
+            >
+              <Stack.Screen name="login" options={{ headerShown: false }} />
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+            <StatusBar style="auto" />
+          </AuthSessionProvider>
+        </ExpoPushTokenProvider>
+      </ThemeProvider>
     </GestureHandlerRootView>
   );
 }

--- a/SORM Symposium/app/login.tsx
+++ b/SORM Symposium/app/login.tsx
@@ -1,0 +1,120 @@
+import { ThemedView } from "@/components/ThemedView";
+import { ThemedText } from "@/components/ThemedText";
+import { Alert, Button, StyleSheet } from "react-native";
+import { router } from "expo-router";
+import { useState } from "react";
+import ThemedTextInput from "@/components/ThemedTextInput";
+import signinUser from "@/api/signinUser";
+
+export default function Login() {
+  const [showLoginScreen, setShowLoginScreen] = useState<boolean>(false);
+  const [login, setLogin] = useState<{
+    email: string;
+    password: string;
+  }>({
+    email: "",
+    password: "",
+  });
+  const [err, setErr] = useState<string>("");
+  const validEmail = /^[A-Za-z0-9]+@[A-Za-z0-9-]+\.[A-Za-z]{2,}$/.test(
+    login.email,
+  );
+
+  const updateLoginDetails = (field: "email" | "password", value: string) => {
+    setLogin((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleLogin = async () => {
+    const { email, password } = login;
+    setErr("");
+    try {
+      await signinUser(email, password);
+      router.push("/");
+    } catch (e) {
+      setErr("Failed to login: " + (e as Error).message);
+    }
+  };
+
+  const navigate = (type: "attendee" | "organizer") => {
+    if (type === "attendee") {
+      router.navigate("/");
+    } else {
+      setShowLoginScreen(true);
+    }
+  };
+
+  const initialJSX = (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Welcome!</ThemedText>
+      <ThemedText>
+        We&apos;re excited you&apos;re here. To continue, please identify who
+        you are:
+      </ThemedText>
+
+      <ThemedText>I am a...</ThemedText>
+      <Button title="Symposium Attendee" onPress={() => navigate("attendee")} />
+      <Button
+        title="Symposium Organizer"
+        onPress={() => navigate("organizer")}
+      />
+    </ThemedView>
+  );
+
+  if (!showLoginScreen) {
+    return initialJSX;
+  }
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Welcome!</ThemedText>
+      <ThemedText>Sign in to continue.</ThemedText>
+
+      <ThemedView style={styles.inputContainer}>
+        <ThemedText>Email</ThemedText>
+        <ThemedTextInput
+          value={login.email}
+          textContentType="emailAddress"
+          onChangeText={(txt) => updateLoginDetails("email", txt)}
+        />
+        {login.email.length > 0 && !validEmail && (
+          <ThemedText style={styles.invalid}>Not a valid email.</ThemedText>
+        )}
+      </ThemedView>
+
+      <ThemedView style={styles.inputContainer}>
+        <ThemedText>Password</ThemedText>
+        <ThemedTextInput
+          value={login.password}
+          textContentType="password"
+          secureTextEntry
+          onChangeText={(txt) => updateLoginDetails("password", txt)}
+        />
+      </ThemedView>
+
+      <Button
+        title="Sign In"
+        onPress={handleLogin}
+        disabled={!validEmail || login.password.length === 0}
+      />
+      <Button title="Back" onPress={() => setShowLoginScreen(false)} />
+      <ThemedText style={styles.invalid}>{err}</ThemedText>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 25,
+    height: "100%",
+  },
+  inputContainer: {
+    marginTop: 5,
+    marginBottom: 5,
+  },
+  invalid: {
+    color: "red",
+  },
+});

--- a/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
@@ -68,7 +68,16 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
             handleEditEvent(event);
           },
         },
-        {
+        event.is_deleted ? {
+          text: 'Reinstate',
+          onPress: () => {
+            setShowAlert(false);
+            setTimeout(() => {
+              handleReinstateEvent(event);
+            }, 100);
+          },
+          style: 'default',
+        } : {
           text: 'Delete',
           onPress: () => {
             setShowAlert(false);
@@ -222,6 +231,30 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
             }
           },
           style: 'destructive',
+        },
+      ],
+    });
+    setShowAlert(true);
+  };
+
+  const handleReinstateEvent = async (event: Event) => {
+    setAlertConfig({
+      title: 'Reinstate Event',
+      message: `Are you sure you want to reinstate "${event.title}"?`,
+      buttons: [
+        {
+          text: 'Cancel',
+          onPress: () => setShowAlert(false),
+          style: 'cancel',
+        },
+        {
+          text: 'Reinstate',
+          onPress: async () => {
+            await updateEvent(event.id, { is_deleted: false });
+            setReloadTrigger(prev => prev + 1);
+            setShowAlert(false);
+          },
+          style: 'default',
         },
       ],
     });

--- a/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
@@ -127,6 +127,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
           speaker_title: event.speaker_title,
           speaker_bio: event.speaker_bio,
           event_date: event.event_date,
+          is_deleted: event.is_deleted,
         };
         await updateEvent(editingEvent.id, updateData);
       } else {
@@ -143,6 +144,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
           speaker_title: event.speaker_title,
           speaker_bio: event.speaker_bio,
           event_date: event.event_date,
+          is_deleted: false,
         };
         await createEvent(createData);
       }
@@ -202,8 +204,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
           text: 'Delete',
           onPress: async () => {
             try {
-              await deleteEvent(event.id);
-              // Trigger a reload of the EventList
+              await updateEvent(event.id, { is_deleted: true });
               setReloadTrigger(prev => prev + 1);
               setShowAlert(false);
             } catch (error) {
@@ -276,8 +277,9 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
       <EventList 
         onSelectEvent={handleEventSelect} 
         showHeader={false} 
+        showDeleted={true}
         reloadTrigger={reloadTrigger}
-          onEventPosition={handleEventPosition}
+        onEventPosition={handleEventPosition}
       />
 
       <AlertModal

--- a/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
@@ -27,7 +27,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
   const [eventPositions] = useState(new Map<number, number>());
   const [headerHeight, setHeaderHeight] = useState(0);
   const [reloadTrigger, setReloadTrigger] = useState(0);
-  const [showDeleted, setShowDeleted] = useState(true);
+  const [showDeleted, setShowDeleted] = useState<'all' | 'active' | 'deleted'>('all');
 
   const [alertConfig, setAlertConfig] = useState<{
     title: string;
@@ -278,18 +278,22 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
           styles.subtitleText, 
           { color: Colors[colorScheme].text },
           !isWideScreen && { flex: 1, textAlign: 'center' }
-        ]} type="subtitle">Showing: {showDeleted ? "All" : "Active"} Events</ThemedText>
+        ]} type="subtitle">Showing: {showDeleted === 'all' ? "All" : 
+              showDeleted === 'active' ? "Active" : "Deleted"} Events</ThemedText>
         <Pressable
           style={[
             styles.addButton,
             { backgroundColor: Colors[colorScheme].adminButton },
             { borderColor: Colors[colorScheme].tint }
           ]}
-          onPress={() => setShowDeleted(!showDeleted)}
+          onPress={() => {setShowDeleted(showDeleted === 'all' ? 'active' : 
+            showDeleted === 'active' ? 'deleted' : 'all'); 
+            setReloadTrigger(prev => prev + 1);
+          }}
         >
           <ThemedText style={[styles.addButtonText,
             { color: Colors[colorScheme].adminButtonText }
-          ]}>Toggle</ThemedText>
+          ]}>Cycle View</ThemedText>
         </Pressable>
       </ThemedView>
     );

--- a/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaEditor.tsx
@@ -11,7 +11,7 @@ import type { Event } from '@/types/Events.types';
 import { createEvent, updateEvent, deleteEvent, getAllEvents } from '@/services/events';
 import { addCurrentYearToDate, isDateValid, isTimeValid } from './utils';
 
-const BREAKPOINT = 700; // Threshold for wide screen
+const BREAKPOINT = 1200; // Threshold for wide screen
 
 interface AgendaEditorProps {
   onShowForm: () => void;
@@ -27,6 +27,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
   const [eventPositions] = useState(new Map<number, number>());
   const [headerHeight, setHeaderHeight] = useState(0);
   const [reloadTrigger, setReloadTrigger] = useState(0);
+  const [showDeleted, setShowDeleted] = useState(true);
 
   const [alertConfig, setAlertConfig] = useState<{
     title: string;
@@ -265,6 +266,35 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
     eventPositions.set(event.id, y);
   };
 
+  const toggleShowDeletedButton = () => {
+    return (
+      <ThemedView style={[
+        styles.toggleButtonContainer,
+        !isWideScreen && { borderColor: Colors[colorScheme].tint, borderWidth: 1, borderRadius: 8, 
+          padding: 8, backgroundColor: Colors[colorScheme].secondaryBackgroundColor }
+      ]}
+      >
+        <ThemedText style={[
+          styles.subtitleText, 
+          { color: Colors[colorScheme].text },
+          !isWideScreen && { flex: 1, textAlign: 'center' }
+        ]} type="subtitle">Showing: {showDeleted ? "All" : "Active"} Events</ThemedText>
+        <Pressable
+          style={[
+            styles.addButton,
+            { backgroundColor: Colors[colorScheme].adminButton },
+            { borderColor: Colors[colorScheme].tint }
+          ]}
+          onPress={() => setShowDeleted(!showDeleted)}
+        >
+          <ThemedText style={[styles.addButtonText,
+            { color: Colors[colorScheme].adminButtonText }
+          ]}>Toggle</ThemedText>
+        </Pressable>
+      </ThemedView>
+    );
+  };
+  
   return (
     <ThemedView style={styles.container}>
       <View 
@@ -277,6 +307,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
             <ThemedText style={[styles.subtitleText, { color: Colors[colorScheme].text }
             ]} type="subtitle">Select an event to edit or delete it</ThemedText>
           )}
+          {isWideScreen && toggleShowDeletedButton()}
           <Pressable
             style={[
               styles.addButton,
@@ -294,6 +325,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
           <ThemedText style={[styles.subtitleText, { color: Colors[colorScheme].text }
           ]} type="subtitle">Select an event to edit or delete it</ThemedText>
         )}
+        {!isWideScreen && toggleShowDeletedButton()}
       </View>
 
       {showForm && (
@@ -310,7 +342,7 @@ export function AgendaEditor({ onShowForm, onCloseForm }: AgendaEditorProps) {
       <EventList 
         onSelectEvent={handleEventSelect} 
         showHeader={false} 
-        showDeleted={true}
+        showDeleted={showDeleted}
         reloadTrigger={reloadTrigger}
         onEventPosition={handleEventPosition}
       />
@@ -346,11 +378,17 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 8,
     borderWidth: 1,
+    marginLeft: 10,
   },
   addButtonText: {
     fontWeight: 'bold',
   },
   subtitleText: {
     fontWeight: 'bold',
+  },
+  toggleButtonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
   },
 });

--- a/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
@@ -11,6 +11,7 @@ type AgendaItemProps = {
   startTime: string;
   endTime: string;
   location: string;
+  isDeleted: boolean;
   onPress: () => void;
 };
 
@@ -19,6 +20,7 @@ export default function AgendaItem({
   startTime,
   endTime,
   location,
+  isDeleted,
   onPress,
 }: AgendaItemProps) {
   const tintColor = Colors[useColorScheme() ?? "light"].tint;
@@ -36,6 +38,7 @@ export default function AgendaItem({
           <ThemedText style={styles.title} type="defaultSemiBold">
             {title}
           </ThemedText>
+          {isDeleted && <ThemedText style={styles.deletedTitle} type="defaultSemiBold"> - Deleted</ThemedText>}
           <IconSymbol name="chevron.right" size={20} color={tintColor} />
         </ThemedView>
         <ThemedView style={styles.infoRow}>
@@ -68,6 +71,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   title: {
+    marginBottom: 3,
+  },
+  deletedTitle: {
+    color: "red",
     marginBottom: 3,
   },
   time: {

--- a/SORM Symposium/components/AgendaViewer/EventForm.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventForm.tsx
@@ -61,6 +61,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
       speaker_name: speakerName,
       speaker_title: speakerTitle,
       speaker_bio: speakerBio,
+      is_deleted: false,
     });
   };
 

--- a/SORM Symposium/components/AgendaViewer/EventForm.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventForm.tsx
@@ -55,7 +55,6 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
       start_time: startTime,
       end_time: endTime,
       created_at: event?.created_at ?? new Date().toISOString(),
-      type: event?.type ?? 'event',
       speaker,
       slides_url: slidesUrl,
       event_date: eventDate,
@@ -153,7 +152,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
               setEventDate(text);
               setCanSubmit(Boolean(title && location && startTime && endTime && text));
             }}
-            placeholder="YYYY-MM-DD"
+            placeholder="MM-DD"
             placeholderTextColor={Colors[colorScheme].text + '80'}
           />
         </View>

--- a/SORM Symposium/components/AgendaViewer/EventList.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventList.tsx
@@ -13,10 +13,11 @@ type EventListProps = {
   onSelectEvent: (event: Event) => void;
   onEventPosition: (event: Event, y: number) => void;
   showHeader?: boolean;
+  showDeleted?: boolean;
   reloadTrigger?: number;
 };
 
-export function EventList({ onSelectEvent, onEventPosition, showHeader = true, reloadTrigger = 0 }: EventListProps) {
+export function EventList({ onSelectEvent, onEventPosition, showHeader = true, showDeleted = false, reloadTrigger = 0 }: EventListProps) {
   const colorScheme = useColorScheme() ?? 'light';
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
@@ -28,7 +29,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, r
     const fetchEvents = async () => {
       try {
         const allEvents = await getAllEvents();
-        setEvents(allEvents);
+        setEvents(allEvents.filter(event => showDeleted || !event.is_deleted));
       } catch (err) {
         console.error("Error fetching events:", err);
         setError("Failed to load events");
@@ -45,14 +46,14 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, r
     setError(null);
 
     // Subscribe to real-time updates
-    const unsubscribe = subscribeToEvents((updatedEvents) => {
-      setEvents(updatedEvents);
+    const subscribe = subscribeToEvents((updatedEvents) => {
+      setEvents(updatedEvents.filter(event => showDeleted || !event.is_deleted));
       setLoading(false);
     });
 
     // Cleanup subscription on unmount
     return () => {
-      unsubscribe();
+      subscribe();
     };
   }, []);
 

--- a/SORM Symposium/components/AgendaViewer/EventList.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventList.tsx
@@ -39,7 +39,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
     };
 
     fetchEvents();
-  }, [reloadTrigger]);
+  }, [reloadTrigger, showDeleted]);
 
   useEffect(() => {
     setLoading(true);

--- a/SORM Symposium/components/AgendaViewer/EventList.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventList.tsx
@@ -125,6 +125,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
                             startTime={item.start_time}
                             endTime={item.end_time}
                             location={item.location}
+                            isDeleted={item.is_deleted}
                             onPress={() => onSelectEvent(item)}
                           />
                         </View>
@@ -138,6 +139,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
                                 startTime={conflictItem.start_time}
                                 endTime={conflictItem.end_time}
                                 location={conflictItem.location}
+                                isDeleted={conflictItem.is_deleted}
                                 onPress={() => onSelectEvent(conflictItem)}
                               />
                             </View>
@@ -167,6 +169,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
                         startTime={item.start_time}
                         endTime={item.end_time}
                         location={item.location}
+                        isDeleted={item.is_deleted}
                         onPress={() => onSelectEvent(item)}
                       />
                     </View>

--- a/SORM Symposium/components/AgendaViewer/EventList.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventList.tsx
@@ -13,11 +13,11 @@ type EventListProps = {
   onSelectEvent: (event: Event) => void;
   onEventPosition: (event: Event, y: number) => void;
   showHeader?: boolean;
-  showDeleted?: boolean;
+  showDeleted?: 'all' | 'active' | 'deleted';
   reloadTrigger?: number;
 };
 
-export function EventList({ onSelectEvent, onEventPosition, showHeader = true, showDeleted = false, reloadTrigger = 0 }: EventListProps) {
+export function EventList({ onSelectEvent, onEventPosition, showHeader = true, showDeleted = 'active', reloadTrigger = 0 }: EventListProps) {
   const colorScheme = useColorScheme() ?? 'light';
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
@@ -29,7 +29,9 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
     const fetchEvents = async () => {
       try {
         const allEvents = await getAllEvents();
-        setEvents(allEvents.filter(event => showDeleted || !event.is_deleted));
+        setEvents(allEvents.filter(event => showDeleted === 'all' 
+          || showDeleted === 'active' && !event.is_deleted 
+          || showDeleted === 'deleted' && event.is_deleted));
       } catch (err) {
         console.error("Error fetching events:", err);
         setError("Failed to load events");
@@ -47,7 +49,9 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
 
     // Subscribe to real-time updates
     const subscribe = subscribeToEvents((updatedEvents) => {
-      setEvents(updatedEvents.filter(event => showDeleted || !event.is_deleted));
+      setEvents(updatedEvents.filter(event => showDeleted === 'all' 
+        || showDeleted === 'active' && !event.is_deleted 
+        || showDeleted === 'deleted' && event.is_deleted));
       setLoading(false);
     });
 
@@ -55,7 +59,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
     return () => {
       subscribe();
     };
-  }, []);
+  }, [showDeleted]);
 
   if (loading) {
     return (

--- a/SORM Symposium/components/AgendaViewer/utils.ts
+++ b/SORM Symposium/components/AgendaViewer/utils.ts
@@ -64,6 +64,52 @@ export function formatTime(minutes: number): string {
   return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
 }
 
+export function isTimeValid(time: string): boolean {
+  // Check for 12-hour format (e.g., "1:30 PM" or "11:45 AM")
+  if (time.includes("AM") || time.includes("PM")) {
+    const [timePart, modifier] = time.split(" ");
+    let [hours, minutes] = timePart.split(":").map(Number);
+
+    // Validate hours and minutes
+    if (isNaN(hours) || isNaN(minutes) || minutes < 0 || minutes >= 60) {
+      return false;
+    }
+
+    // Validate hours based on AM/PM
+    if (modifier.toUpperCase() === "AM") {
+      return hours >= 1 && hours <= 12;
+    } else if (modifier.toUpperCase() === "PM") {
+      return hours >= 1 && hours <= 12;
+    }
+    return false;
+  }
+
+  // Check for 24-hour format (e.g., "13:30" or "09:45")
+  const [hours, minutes] = time.split(":").map(Number);
+  return !isNaN(hours) && !isNaN(minutes) && 
+         hours >= 0 && hours < 24 && 
+         minutes >= 0 && minutes < 60;
+}
+
+export function isDateValid(date: string): boolean {
+  const [year, month, day] = date.split('-').map(Number);
+  if (isNaN(year) || isNaN(month) || isNaN(day) || month < 1 || month > 12 || day < 1 || day > 31) {
+    return false;
+  }
+  return !isNaN(new Date(year, month - 1, day).getTime());
+}
+
+/**
+ * Adds the current year to a date string that doesn't include a year.
+ * @param dateString - Date string in MM-DD format
+ * @returns Date string in YYYY-MM-DD format
+ */
+export function addCurrentYearToDate(dateString: string): string {
+  const currentYear = new Date().getFullYear();
+  const [month, day] = dateString.split('-');
+  return `${currentYear}-${month}-${day}`;
+} 
+
 type EventsByDate = {
   [date: string]: Event[];
 };

--- a/SORM Symposium/components/AuthSessionProvider.tsx
+++ b/SORM Symposium/components/AuthSessionProvider.tsx
@@ -1,0 +1,29 @@
+import { supabase } from "@/constants/supabase";
+import { Session } from "@supabase/supabase-js";
+import { ReactNode, useEffect, useState, createContext } from "react"
+
+const AuthSessionContext = createContext<Session | null | undefined>(undefined);
+
+type AuthSessionProviderProps = {
+  children: ReactNode;
+};
+
+function AuthSessionProvider({ children }: AuthSessionProviderProps) {
+  const [session, setSession] = useState<Session | null>(null);
+  
+  useEffect(() => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => {
+      setSession(session);
+    });
+    
+    return subscription.unsubscribe;
+  }, []);
+  
+  return (
+    <AuthSessionContext.Provider value={session}>
+      {children}
+    </AuthSessionContext.Provider>
+  )
+}
+
+export { AuthSessionContext, AuthSessionProvider };

--- a/SORM Symposium/components/ExpoPushTokenProvider.tsx
+++ b/SORM Symposium/components/ExpoPushTokenProvider.tsx
@@ -6,6 +6,7 @@ import * as Application from "expo-application";
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 import saveExpoPushToken from "@/api/saveExpoPushToken";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const ExpoPushTokenContext = createContext<string | null>(null);
 
@@ -79,6 +80,12 @@ function ExpoPushTokenProvider({ children }: ExpoPushTokenProviderProps) {
       setToken(token);
 
       await saveExpoPushToken(token, deviceId);
+
+      try {
+        await AsyncStorage.setItem("created-expo-token", "true");
+      } catch (e) {
+        console.error("Failed to set `created-expo-token` in storage...");
+      }
     }
 
     const notificationListener = Notifications.addNotificationReceivedListener(

--- a/SORM Symposium/hooks/useSupabaseAuth.ts
+++ b/SORM Symposium/hooks/useSupabaseAuth.ts
@@ -1,0 +1,20 @@
+import { AuthSessionContext } from "@/components/AuthSessionProvider";
+import { useContext } from "react";
+
+/**
+ * Get the current user session.
+ * @returns the Session object returned by Supabase, if there is a user session.
+ */
+function useSupabaseAuth() {
+  const context = useContext(AuthSessionContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useSupabaseAuth must be used within an AuthSessionProvider."
+    );
+  }
+
+  return context;
+}
+
+export default useSupabaseAuth;

--- a/SORM Symposium/package-lock.json
+++ b/SORM Symposium/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2764,6 +2765,17 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
+      "integrity": "sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -7869,6 +7881,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8851,6 +8871,17 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/SORM Symposium/package.json
+++ b/SORM Symposium/package.json
@@ -41,7 +41,8 @@
     "expo-notifications": "~0.31.2",
     "expo-device": "~7.1.4",
     "expo-dev-client": "~5.1.8",
-    "expo-application": "~6.1.4"
+    "expo-application": "~6.1.4",
+    "@react-native-async-storage/async-storage": "2.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/SORM Symposium/types/Events.types.ts
+++ b/SORM Symposium/types/Events.types.ts
@@ -6,7 +6,6 @@ export interface Event {
   end_time: string;
   location: string;
   description: string | null;
-  type: string | null;
   speaker: string | null;
   slides_url: string | null;
   speaker_name: string | null;

--- a/SORM Symposium/types/Events.types.ts
+++ b/SORM Symposium/types/Events.types.ts
@@ -12,4 +12,5 @@ export interface Event {
   speaker_title: string | null;
   speaker_bio: string | null;
   event_date: string;
+  is_deleted: boolean;
 } 


### PR DESCRIPTION
The Agenda Editor in the admin page can now add events to the database. events can also be deleted, though this doesn't actually remove them from the database. Instead, they are marked as deleted and hidden on the agenda page. The admin page's agenda viewer can toggle between showing all events, only active events, or only deleted events. Deleted events can be reinstated from the admin page. 