### PR TITLE
Sca 35 update schedule appearance

### DIFF
--- a/SORM Symposium/app/(tabs)/agenda.tsx
+++ b/SORM Symposium/app/(tabs)/agenda.tsx
@@ -40,6 +40,13 @@ function areTimesConflicting(
   return startA < endB && startB < endA;
 }
 
+function calculateTimeOffset(startTimeA: string, startTimeB: string): number {
+  const timeA = convert12HrFormatToSeconds(startTimeA);
+  const timeB = convert12HrFormatToSeconds(startTimeB);
+  // Convert time difference to pixels (e.g., 30 minutes = 50 pixels)
+  return Math.max(0, (timeB - timeA) * (50 / 1800)); // 1800 seconds = 30 minutes
+}
+
 // Placeholder data for agenda items
 const placeholderAgendaItems = [
   {
@@ -62,6 +69,20 @@ const placeholderAgendaItems = [
     startTime: "8:30 AM",
     endTime: "10:30 AM",
     location: "Auditorium A",
+  },
+  {
+    id: "4",
+    title: "Lunch Break",
+    startTime: "12:30 PM",
+    endTime: "1:30 PM",
+    location: "Main Hall",
+  },
+  {
+    id: "5",
+    title: "Afternoon Session",
+    startTime: "1:00 PM",
+    endTime: "3:00 PM",
+    location: "Auditorium B",
   },
 ];
 
@@ -132,11 +153,17 @@ export default function AgendaScreen() {
                   />
                   <View style={{ flex: 1 }}>
                     {item.conflictingItems.map((conflictItem) => (
-                      <AgendaItem
+                      <View 
                         key={conflictItem.id}
-                        onPress={() => navigateToEvent(conflictItem.id)}
-                        {...conflictItem}
-                      />
+                        style={{
+                          marginTop: calculateTimeOffset(item.startTime, conflictItem.startTime)
+                        }}
+                      >
+                        <AgendaItem
+                          onPress={() => navigateToEvent(conflictItem.id)}
+                          {...conflictItem}
+                        />
+                      </View>
                     ))}
                   </View>
                 </View>
@@ -170,6 +197,7 @@ const styles = StyleSheet.create({
   conflictContent: {
     gap: 8,
     flexDirection: "row",
+    alignItems: "flex-start",
   },
   header: {
     marginTop: 16,

--- a/SORM Symposium/app/(tabs)/agenda.tsx
+++ b/SORM Symposium/app/(tabs)/agenda.tsx
@@ -55,11 +55,13 @@ function areTimesConflicting(
   return startA < endB && startB < endA;
 }
 
+const PIXELS_PER_MINUTE = 130 / 60; // Same as in AgendaItem.tsx (130px per hour)
+
 function calculateTimeOffset(startTimeA: string, startTimeB: string): number {
-  const timeA = convert12HrFormatToSeconds(startTimeA);
-  const timeB = convert12HrFormatToSeconds(startTimeB);
-  // Convert time difference to pixels (e.g., 30 minutes = 50 pixels)
-  return Math.max(0, (timeB - timeA) * (50 / 1800)); // 1800 seconds = 30 minutes
+  const timeA = convert12HrTimeToSeconds(startTimeA);
+  const timeB = convert12HrTimeToSeconds(startTimeB);
+  // Convert time difference to pixels
+  return Math.max(0, (timeB - timeA) / 60 * PIXELS_PER_MINUTE);
 }
 
 type EventsByDate = {
@@ -199,7 +201,8 @@ export default function AgendaScreen() {
                           location={item.location}
                           onPress={() => navigateToEvent(item.id)}
                         />
-                        <View style={{ flex: 1 }}>
+                        <View style={[{ flex: 1 }, 
+                          { marginTop: calculateTimeOffset(item.start_time, item.conflictingItems[0].start_time) }]}>
                           {item.conflictingItems.map((conflictItem) => (
                             <AgendaItem
                               key={conflictItem.id}

--- a/SORM Symposium/app/event/[id].tsx
+++ b/SORM Symposium/app/event/[id].tsx
@@ -86,22 +86,22 @@ export default function EventDetailScreen() {
             </ThemedText>
           </ThemedView>
 
-          <ThemedView style={styles.infoRow}>
+          {event.title !== "Break" && <ThemedView style={styles.infoRow}>
             <IconSymbol
               name="mappin.circle.fill"
               size={20}
               color={Colors[colorScheme].tabIconDefault}
             />
             <ThemedText style={styles.infoText}>{event.location}</ThemedText>
-          </ThemedView>
+          </ThemedView>}
         </ThemedView>
 
-        <ThemedView style={styles.section}>
+        {event.title !== "Break" && <ThemedView style={styles.section}>
           <ThemedText type="subtitle">About</ThemedText>
           <ThemedText style={styles.description}>
             {event.description || "No description available."}
           </ThemedText>
-        </ThemedView>
+        </ThemedView>}
 
         {event.speaker_name && (
           <>

--- a/SORM Symposium/components/AgendaItem.tsx
+++ b/SORM Symposium/components/AgendaItem.tsx
@@ -13,6 +13,13 @@ type AgendaItemProps = {
   onPress: () => void;
 };
 
+const BASE_HEIGHT = 130; // Base height for 1-hour events
+
+const calculateHeight = (startTime: string, endTime: string) => {
+  const duration = parseInt(endTime) - parseInt(startTime);
+  return Math.max(BASE_HEIGHT, BASE_HEIGHT * duration);
+};
+
 export default function AgendaItem({
   title,
   startTime,
@@ -29,6 +36,7 @@ export default function AgendaItem({
         styles.agendaItem,
         { backgroundColor: Colors[colorScheme].secondaryBackgroundColor },
         { borderColor: Colors[colorScheme].tint },
+        { minHeight: calculateHeight(startTime, endTime) },
         pressed && styles.agendaItemPressed,
       ]}
       onPress={onPress}
@@ -88,7 +96,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "white",
     flexDirection: "row",
-    alignItems: "center",
+    alignItems: "stretch",
     userSelect: "none",
   },
   agendaItemPressed: {
@@ -96,6 +104,7 @@ const styles = StyleSheet.create({
   },
   agendaContent: {
     flex: 1,
+    display: "flex",
     padding: 8,
   },
 });

--- a/SORM Symposium/components/AgendaItem.tsx
+++ b/SORM Symposium/components/AgendaItem.tsx
@@ -20,17 +20,22 @@ export default function AgendaItem({
   location,
   onPress,
 }: AgendaItemProps) {
-  const tintColor = Colors[useColorScheme() ?? "light"].tint;
+  const colorScheme = useColorScheme() ?? "light";
+  const tintColor = Colors[colorScheme].tint;
 
   return (
     <Pressable
       style={({ pressed }) => [
         styles.agendaItem,
+        { backgroundColor: Colors[colorScheme].secondaryBackgroundColor },
+        { borderColor: Colors[colorScheme].tint },
         pressed && styles.agendaItemPressed,
       ]}
       onPress={onPress}
     >
-      <ThemedView style={styles.agendaContent}>
+      <ThemedView style={[styles.agendaContent, 
+        { backgroundColor: colorScheme === "light" 
+          ? Colors[colorScheme].background : Colors[colorScheme].background }]}>
         <ThemedView style={styles.titleContainer}>
           <ThemedText style={styles.title} type="defaultSemiBold">
             {title}
@@ -61,10 +66,12 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
     marginTop: 4,
+    backgroundColor: "transparent",
   },
   titleContainer: {
     flexDirection: "row",
     alignItems: "center",
+    backgroundColor: "transparent",
   },
   title: {
     marginBottom: 3,
@@ -73,9 +80,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   agendaItem: {
-    backgroundColor: "rgba(0, 0, 0, 0.05)",
     borderRadius: 8,
-    padding: 16,
+    padding: 12,
     marginBottom: 12,
     flex: 1,
     minWidth: 0,
@@ -90,5 +96,6 @@ const styles = StyleSheet.create({
   },
   agendaContent: {
     flex: 1,
+    padding: 8,
   },
 });

--- a/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
@@ -4,6 +4,7 @@ import { IconSymbol } from "@/components/ui/IconSymbol";
 import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme.web";
 import { formatTimeRange } from "@/lib/dateTime";
+import { calculateHeight } from "./utils";
 import { Pressable, StyleSheet } from "react-native";
 
 type AgendaItemProps = {
@@ -13,13 +14,6 @@ type AgendaItemProps = {
   location: string;
   isDeleted: boolean;
   onPress: () => void;
-};
-
-const BASE_HEIGHT = 130; // Base height for 1-hour events
-
-const calculateHeight = (startTime: string, endTime: string) => {
-  const duration = parseInt(endTime) - parseInt(startTime);
-  return Math.max(BASE_HEIGHT, BASE_HEIGHT * duration);
 };
 
 export default function AgendaItem({

--- a/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
@@ -33,7 +33,7 @@ export default function AgendaItem({
         styles.agendaItem,
         { backgroundColor: Colors[colorScheme].secondaryBackgroundColor },
         { borderColor: Colors[colorScheme].tint },
-        { minHeight: calculateHeight(startTime, endTime) },
+        { minHeight: title === "Break" ? 65 : calculateHeight(startTime, endTime) },
         pressed && styles.agendaItemPressed,
       ]}
       onPress={onPress}
@@ -54,10 +54,10 @@ export default function AgendaItem({
             {formatTimeRange(startTime, endTime)}
           </ThemedText>
         </ThemedView>
-        <ThemedView style={styles.infoRow}>
+        {title !== "Break" && <ThemedView style={styles.infoRow}>
           <IconSymbol name="mappin.circle.fill" size={16} color={tintColor} />
           <ThemedText style={styles.location}>{location}</ThemedText>
-        </ThemedView>
+        </ThemedView>}
       </ThemedView>
     </Pressable>
   );

--- a/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
+++ b/SORM Symposium/components/AgendaViewer/AgendaItem.tsx
@@ -93,7 +93,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 12,
     marginBottom: 12,
-    flex: 1,
     minWidth: 0,
     borderWidth: 1,
     borderColor: "white",

--- a/SORM Symposium/components/AgendaViewer/EventForm.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventForm.tsx
@@ -88,7 +88,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
             value={title}
             onChangeText={(text) => {
               setTitle(text);
-              setCanSubmit(Boolean(text && location && startTime && endTime && eventDate));
+              setCanSubmit(Boolean(text && (title !== "Break" ? location : true) && startTime && endTime && eventDate));
             }}
             placeholder="Event title"
             placeholderTextColor={Colors[colorScheme].text + '80'}
@@ -151,7 +151,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
             value={eventDate}
             onChangeText={(text) => {
               setEventDate(text);
-              setCanSubmit(Boolean(title && location && startTime && endTime && text));
+              setCanSubmit(Boolean(title && (title !== "Break" ? location : true) && startTime && endTime && text));
             }}
             placeholder="MM-DD"
             placeholderTextColor={Colors[colorScheme].text + '80'}
@@ -172,7 +172,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
             value={startTime}
             onChangeText={(text) => {
               setStartTime(text);
-              setCanSubmit(Boolean(title && location && text && endTime && eventDate));
+              setCanSubmit(Boolean(title && (title !== "Break" ? location : true) && text && endTime && eventDate));
             }}
             placeholder="e.g. 9:00 AM"
             placeholderTextColor={Colors[colorScheme].text + '80'}
@@ -193,7 +193,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
             value={endTime}
             onChangeText={(text) => {
               setEndTime(text);
-              setCanSubmit(Boolean(title && location && startTime && text && eventDate));
+              setCanSubmit(Boolean(title && (title !== "Break" ? location : true) && startTime && text && eventDate));
             }}
             placeholder="e.g. 10:30 AM"
             placeholderTextColor={Colors[colorScheme].text + '80'}

--- a/SORM Symposium/components/AgendaViewer/EventForm.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventForm.tsx
@@ -130,7 +130,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
             value={location}
             onChangeText={(text) => {
               setLocation(text);
-              setCanSubmit(Boolean(title && text && startTime && endTime && eventDate));
+              setCanSubmit(Boolean(title && (title !== "Break" ? text : true) && startTime && endTime && eventDate));
             }}
             placeholder="Event location"
             placeholderTextColor={Colors[colorScheme].text + '80'}

--- a/SORM Symposium/components/AgendaViewer/EventList.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventList.tsx
@@ -123,7 +123,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
                           });
                         }}
                       >
-                        <View style={styles.eventWrapper}>
+                        <View style={[styles.eventWrapper, { alignSelf: 'flex-start' }]}>
                           <AgendaItem
                             title={item.title}
                             startTime={item.start_time}

--- a/SORM Symposium/components/AgendaViewer/EventList.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventList.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet, ScrollView } from 'react-native';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import type { Event } from '@/types/Events.types';
 import AgendaItem from '@/components/AgendaViewer/AgendaItem';
-import { findConflicts, groupEventsByDate } from './utils';
+import { findConflicts, groupEventsByDate, calculateEventOffset } from './utils';
 import { getAllEvents, subscribeToEvents } from '@/services/events';
 import { ThemedView } from '../ThemedView';
 import { ThemedText } from '../ThemedText';
@@ -137,6 +137,7 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
                           {item.conflictingItems.map((conflictItem) => (
                             <View 
                               key={conflictItem.id}
+                              style={{ marginTop: calculateEventOffset(item.start_time, conflictItem.start_time) }}
                             >
                               <AgendaItem
                                 title={conflictItem.title}
@@ -232,6 +233,5 @@ const styles = StyleSheet.create({
   conflictContent: {
     flexDirection: 'row',
     gap: 8,
-    marginBottom: 8,
   },
 }); 

--- a/SORM Symposium/components/AgendaViewer/utils.ts
+++ b/SORM Symposium/components/AgendaViewer/utils.ts
@@ -127,12 +127,27 @@ export const findConflicts = (events: Event[]) => {
   const conflictIds = new Set<number>();
   const items = [];
 
-  for (const item of events) {
+  // Sort events by start time, and for events with same start time, sort by duration (longer first)
+  const sortedEvents = [...events].sort((a, b) => {
+    const startTimeA = convert24HrTimeToSeconds(a.start_time);
+    const startTimeB = convert24HrTimeToSeconds(b.start_time);
+    
+    if (startTimeA !== startTimeB) {
+      return startTimeA - startTimeB;
+    }
+    
+    // If start times are equal, sort by duration (longer first)
+    const durationA = convert24HrTimeToSeconds(a.end_time) - startTimeA;
+    const durationB = convert24HrTimeToSeconds(b.end_time) - startTimeB;
+    return durationB - durationA;
+  });
+
+  for (const item of sortedEvents) {
     if (conflictIds.has(item.id)) {
       continue;
     }
 
-    const conflicts = events.filter(
+    const conflicts = sortedEvents.filter(
       (conflictItem) =>
         conflictItem.id !== item.id &&
         areTimesConflicting(

--- a/SORM Symposium/components/AgendaViewer/utils.ts
+++ b/SORM Symposium/components/AgendaViewer/utils.ts
@@ -166,3 +166,15 @@ export function formatConflictMessage(conflict: TimeConflict): string {
     return `${event1.title} (${event1.start_time}-${event1.end_time}) overlaps with ${event2.title} (${event2.start_time}-${event2.end_time})`;
   }
 } 
+
+export function calculateEventOffset(startTimeA: string, startTimeB: string): number {
+  const startA = convert24HrTimeToSeconds(startTimeA);
+  const startB = convert24HrTimeToSeconds(startTimeB);
+  return Math.max(0, (startB - startA) * (65 / 1800)); // 130px per hour
+}
+
+export function calculateHeight(startTime: string, endTime: string): number {
+  const duration = convert24HrTimeToSeconds(endTime) - convert24HrTimeToSeconds(startTime);
+  const BASE_HEIGHT = 130;
+  return Math.max(BASE_HEIGHT, BASE_HEIGHT / 3600 * duration);
+}


### PR DESCRIPTION
Various updates to the agenda's appearance. In addition to minor improvements on the visual styling, the following changes have been made.

**Event Heights**
Events' AgendaItems are now taller if they have a longer duration. A minimum height is used for events that are 1 hour or shorter. 

**Break Events**
Events with the title "Break" gain special alterations. 
- Breaks don't require or display a location. 
- Breaks don't show an "About" section when selected in the Agenda tab.
- AgendaItems for Breaks are allowed to be shorter than the normal minimum height.

**Event Offsets**
Concurrent events that start at different times are vertically offset to visually indicate as such. The offset is based on the difference in the start times. The offset is compatible with the event heights change such that events are displayed nearly chronologically based on their start and end times. The only time this is not accurate is when text-wrapping forces an AgendaItem to be taller than it should otherwise be. 