### PR TITLE
Sca 41 fix startup route

### DIFF
--- a/SORM Symposium/app/(tabs)/_layout.tsx
+++ b/SORM Symposium/app/(tabs)/_layout.tsx
@@ -12,7 +12,7 @@ export default function TabLayout() {
 
   return (
     <Tabs
-      initialRouteName="index"
+      initialRouteName="home"
       screenOptions={{
         tabBarActiveTintColor:
           Colors[useColorScheme() ?? "light"].tabIconSelected,
@@ -37,7 +37,7 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="index"
+        name="home"
         options={{
           title: "Home",
           tabBarIcon: ({ color }) => (

--- a/SORM Symposium/app/(tabs)/home.tsx
+++ b/SORM Symposium/app/(tabs)/home.tsx
@@ -20,7 +20,7 @@ import {
 const width = () => Math.min(Dimensions.get("window").width, 500);
 const height = () => (width() * 182) / 500;
 
-export default function Index() {
+export default function Home() {
   const navigateToAllAnnouncements = () => {
     router.push("/announcement/announcementList");
   };

--- a/SORM Symposium/app/+not-found.tsx
+++ b/SORM Symposium/app/+not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFoundScreen() {
       <Stack.Screen options={{ title: 'Oops!' }} />
       <ThemedView style={styles.container}>
         <ThemedText type="title">This screen does not exist.</ThemedText>
-        <Link href="/" style={styles.link}>
+        <Link href="/home" style={styles.link}>
           <ThemedText type="link">Go to home screen!</ThemedText>
         </Link>
       </ThemedView>

--- a/SORM Symposium/app/_layout.tsx
+++ b/SORM Symposium/app/_layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout() {
                   },
                 }}
               >
-                <Stack.Screen name="login" options={{ headerShown: false }} />
+                <Stack.Screen name="index" options={{ headerShown: false }} />
                 <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
                 <Stack.Screen name="+not-found" />
               </Stack>

--- a/SORM Symposium/app/index.tsx
+++ b/SORM Symposium/app/index.tsx
@@ -32,7 +32,7 @@ export default function Login() {
     setErr("");
     try {
       await signinUser(email, password);
-      router.push("/");
+      router.push("/(tabs)/home");
     } catch (e) {
       setErr("Failed to login: " + (e as Error).message);
     }
@@ -40,7 +40,7 @@ export default function Login() {
 
   const navigate = (type: "attendee" | "organizer") => {
     if (type === "attendee") {
-      router.navigate("/");
+      router.navigate("/(tabs)/home");
     } else {
       setShowLoginScreen(true);
     }


### PR DESCRIPTION
A routing issue where the app would load to the home page instead of the login on web. Files have been renamed so the login page is always loaded first. References to the changed files have been changed accordingly.