### PR TITLE
Sca 54 dont show seconds

### DIFF
--- a/SORM Symposium/app/(tabs)/admin.tsx
+++ b/SORM Symposium/app/(tabs)/admin.tsx
@@ -21,7 +21,7 @@ export default function Admin() {
   const agendaEditorRef = useRef<View>(null);
 
   if (!user) {
-    return <Redirect href="/(tabs)" />;
+    return <Redirect href="/(tabs)/home" />;
   }
 
   const scrollToAgendaEditor = () => {

--- a/SORM Symposium/components/AgendaViewer/EventForm.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventForm.tsx
@@ -5,6 +5,7 @@ import { ThemedView } from '@/components/ThemedView';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import type { Event } from '@/types/Events.types';
+import { removeSecondsFromTime } from './utils';
 
 type EventFormProps = {
   event?: Event;
@@ -169,7 +170,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
                 borderColor: Colors[colorScheme].text + '40',
               }
             ]}
-            value={startTime}
+            value={removeSecondsFromTime(startTime)}
             onChangeText={(text) => {
               setStartTime(text);
               setCanSubmit(Boolean(title && (title !== "Break" ? location : true) && text && endTime && eventDate));
@@ -190,7 +191,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
                 borderColor: Colors[colorScheme].text + '40',
               }
             ]}
-            value={endTime}
+            value={removeSecondsFromTime(endTime)}
             onChangeText={(text) => {
               setEndTime(text);
               setCanSubmit(Boolean(title && (title !== "Break" ? location : true) && startTime && text && eventDate));

--- a/SORM Symposium/components/AgendaViewer/utils.ts
+++ b/SORM Symposium/components/AgendaViewer/utils.ts
@@ -64,7 +64,23 @@ export function formatTime(minutes: number): string {
   return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`;
 }
 
+export function removeSecondsFromTime(time: string): string {
+  const parts = time.split(":");
+  if (parts.length === 3) {
+    // HH:mm:ss -> HH:mm
+    return `${parts[0]}:${parts[1]}`;
+  } else if (parts.length === 2) {
+    // HH:mm -> HH:mm
+    return time;
+  }
+  // If format is unexpected, return as is
+  return time;
+}
+
 export function isTimeValid(time: string): boolean {
+  // Remove seconds from time, if present
+  time = removeSecondsFromTime(time);
+
   // Check for 12-hour format (e.g., "1:30 PM" or "11:45 AM")
   if (time.includes("AM") || time.includes("PM")) {
     const [timePart, modifier] = time.split(" ");


### PR DESCRIPTION
I changed the EventForm so it doesn't show seconds for start and end times when loading an event, and it doesn't require seconds to be inputted for the start and end times of an event.

Also fixed a minor routing issue artifact from SCA-41 change