### PR TITLE
Sca 39 organize events by room

### DIFF
--- a/SORM Symposium/components/AgendaViewer/EventList.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventList.tsx
@@ -183,16 +183,51 @@ export function EventList({ onSelectEvent, onEventPosition, showHeader = true, s
                         });
                       }}
                     >
-                      <View style={[styles.eventWrapper]}>
-                        <AgendaItem
-                          title={item.title}
-                          startTime={item.start_time}
-                          endTime={item.end_time}
-                          location={item.location}
-                          isDeleted={item.is_deleted}
-                          onPress={() => onSelectEvent(item)}
-                        />
-                      </View>
+                      {item.location === COL_1_LOCATION ? (
+                        <>
+                          <View style={[styles.eventWrapper, { alignSelf: 'flex-start' }]}>
+                            <AgendaItem
+                              title={item.title}
+                              startTime={item.start_time}
+                              endTime={item.end_time}
+                              location={item.location}
+                              isDeleted={item.is_deleted}
+                              onPress={() => onSelectEvent(item)}
+                            />
+                          </View>
+                          <View style={styles.eventWrapper}>
+                            {/* Empty right column */}
+                          </View>
+                        </>
+                      ) : item.location === COL_2_LOCATION ? (
+                        <>
+                          <View style={[styles.eventWrapper, { alignSelf: 'flex-start' }]}>
+                            {/* Empty left column */}
+                          </View>
+                          <View style={styles.eventWrapper}>
+                            <AgendaItem
+                              title={item.title}
+                              startTime={item.start_time}
+                              endTime={item.end_time}
+                              location={item.location}
+                              isDeleted={item.is_deleted}
+                              onPress={() => onSelectEvent(item)}
+                            />
+                          </View>
+                        </>
+                      ) : (
+                        // Event with other location or null - use single column layout
+                        <View style={[styles.eventWrapper]}>
+                          <AgendaItem
+                            title={item.title}
+                            startTime={item.start_time}
+                            endTime={item.end_time}
+                            location={item.location}
+                            isDeleted={item.is_deleted}
+                            onPress={() => onSelectEvent(item)}
+                          />
+                        </View>
+                      )}
                     </View>
                   );
                 })}

--- a/SORM Symposium/components/AgendaViewer/utils.ts
+++ b/SORM Symposium/components/AgendaViewer/utils.ts
@@ -139,6 +139,28 @@ export function groupEventsByDate(events: Event[]): EventsByDate {
   }, {});
 }
 
+export function sortEventsByLocation(events: Event[], col1Location: string, col2Location: string): Event[] {
+  events.sort((a, b) => {
+    // Events with COL_1_LOCATION go to left column (first)
+    const aIsCol1 = a.location === col1Location;
+    const bIsCol1 = b.location === col1Location;
+    
+    if (aIsCol1 && !bIsCol1) return -1;
+    if (!aIsCol1 && bIsCol1) return 1;
+    
+    // Events with COL_2_LOCATION go to right column (last)
+    const aIsCol2 = a.location === col2Location;
+    const bIsCol2 = b.location === col2Location;
+    
+    if (aIsCol2 && !bIsCol2) return 1;
+    if (!aIsCol2 && bIsCol2) return -1;
+    
+    // For events with same location priority, maintain original order
+    return 0;
+  });
+  return events;
+}
+
 export const findConflicts = (events: Event[]) => {
   const conflictIds = new Set<number>();
   const items = [];


### PR DESCRIPTION
Changed event-ordering logic. Now there are two keywords, one for each breakout location. If an event has a location matching a keyword, it is placed in the respective column (even if there is no conflicting event). Events with other locations (or no location) are displayed across both columns, unless there are two conflicting events. 

**Conflict Behavior**
If two breakout-events (events with locations matching the column keywords) overlap, they are placed in their appropriate columns. If they both have the same location, one will be placed in the wrong column (order is not guaranteed).
If a breakout event and a non-breakout event overlap, the breakout event is placed first according to its location, and then the non-breakout event is placed in the other column. 
If two non-breakout events overlap, they are placed according to prior logic. The earlier event is placed on the left, and if the events start at the same time, the longer event is placed first.