### PR TITLE
SCA-61 Fixed reinstating issue

### DIFF
--- a/SORM Symposium/components/AgendaViewer/EventForm.tsx
+++ b/SORM Symposium/components/AgendaViewer/EventForm.tsx
@@ -62,7 +62,7 @@ export function EventForm({ event, onSubmit, onCancel }: EventFormProps) {
       speaker_name: speakerName,
       speaker_title: speakerTitle,
       speaker_bio: speakerBio,
-      is_deleted: false,
+      is_deleted: event?.is_deleted ?? false,
     });
   };
 


### PR DESCRIPTION
Fixed an issue where a deleted event would be reinstated when edited. Now, deleted events will remain deleted even if they are edited (the only way to reinstate it is through the menu that appears when you select the event).