### PR TITLE
Sca 70 cache contacts

### DIFF
--- a/SORM Symposium/.gitignore
+++ b/SORM Symposium/.gitignore
@@ -41,6 +41,9 @@ yarn-error.*
 supabase/.branches
 supabase/.temp
 
+# Drizzle
+/drizzle
+
 # typescript
 *.tsbuildinfo
 

--- a/SORM Symposium/app.json
+++ b/SORM Symposium/app.json
@@ -37,7 +37,8 @@
           "resizeMode": "contain",
           "backgroundColor": "#ffffff"
         }
-      ]
+      ],
+      "expo-sqlite"
     ],
     "experiments": {
       "typedRoutes": true

--- a/SORM Symposium/app/(tabs)/info.tsx
+++ b/SORM Symposium/app/(tabs)/info.tsx
@@ -44,8 +44,8 @@ export default function InfoScreen() {
 
   // Fetch contacts from Supabase
   const {
-    contacts,
-    loading: contactsLoading,
+    data: contacts = [],
+    isFetching: contactsLoading,
     error: contactsError,
   } = useContacts();
 
@@ -306,7 +306,7 @@ export default function InfoScreen() {
             )}
             {contactsError && (
               <ThemedText style={[styles.contactText, { color: "red" }]}>
-                Failed to load contacts.
+                Failed to load contacts: {contactsError.message}
               </ThemedText>
             )}
             {!contactsLoading && !contactsError && contacts.length === 0 && (

--- a/SORM Symposium/app/(tabs)/info.tsx
+++ b/SORM Symposium/app/(tabs)/info.tsx
@@ -4,7 +4,7 @@ import { ThemedView } from "@/components/ThemedView";
 import type { IconSymbolName } from "@/components/ui/IconSymbol";
 import { IconSymbol } from "@/components/ui/IconSymbol";
 import { Colors } from "@/constants/Colors";
-import { ContactInfo, useContacts } from "@/hooks/useContacts";
+import useContacts, { ContactInfo } from "@/hooks/useContacts";
 import { Image } from "expo-image";
 import React, { useState } from "react";
 import {

--- a/SORM Symposium/app/_layout.tsx
+++ b/SORM Symposium/app/_layout.tsx
@@ -18,29 +18,36 @@ import { AuthSessionProvider } from "@/components/AuthSessionProvider";
 import { sendLogMessage } from "@/services/logging";
 import { ActiveUsersProvider } from "@/components/ActiveUsersProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { openDatabaseSync, SQLiteProvider } from "expo-sqlite";
 import { asc } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/expo-sqlite";
 import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import migrations from "@/drizzle/migrations";
 import * as schema from "@/db/schema";
+import getCacheDatabase from "@/db";
+import { Platform } from "react-native";
 
 // Enable screens for better performance
 enableScreens();
 
-const DATABASE_NAME = "cache.db";
-
 // Open the SQLite database synchronously
-const expo = openDatabaseSync(DATABASE_NAME);
-const db = drizzle<typeof schema>(expo);
+const { db, databaseName, SQLiteProvider } = getCacheDatabase();
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 const PREFETCH_QUERIES: Parameters<typeof queryClient.prefetchQuery>[number][] =
   [
     {
       queryKey: ["contacts"],
       queryFn: async function () {
+        if (!db) {
+          return [];
+        }
+
         const data = await db
           .select()
           .from(schema.contact_info)
@@ -62,6 +69,7 @@ export default function RootLayout() {
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
   const { top: topInset } = useSafeAreaInsets();
+  // @ts-ignore
   const { success, error } = useMigrations(db, migrations);
 
   useEffect(() => {
@@ -79,9 +87,14 @@ export default function RootLayout() {
       }
     }
 
-    // Prefetch cache from SQLite,
+    // Prefetch cache from SQLite (if on native platforms)
     // so that it's shown immediately before useQuery is called.
+    // If on web, the prefetch queries will be ignored.
     async function prefetchCache() {
+      if (Platform.OS === "web") {
+        console.warn("Skipping prefetching cache on web platform.");
+        return;
+      }
       try {
         await Promise.all(
           PREFETCH_QUERIES.map((query) => queryClient.prefetchQuery(query)),
@@ -108,6 +121,29 @@ export default function RootLayout() {
     return null;
   }
 
+  const Screens = (
+    <>
+      <Stack
+        screenOptions={{
+          contentStyle: {
+            paddingTop: topInset,
+          },
+        }}
+      >
+        <Stack.Screen
+          name="index"
+          options={{ headerShown: false, title: "Login" }}
+        />
+        <Stack.Screen
+          name="(tabs)"
+          options={{ headerShown: false, title: "SORM Symposium" }}
+        />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+      <StatusBar style="auto" />
+    </>
+  );
+
   return (
     <QueryClientProvider client={queryClient}>
       <GestureHandlerRootView style={{ flex: 1 }}>
@@ -117,26 +153,13 @@ export default function RootLayout() {
           <ExpoPushTokenProvider>
             <AuthSessionProvider>
               <ActiveUsersProvider>
-                <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
-                  <Stack
-                    screenOptions={{
-                      contentStyle: {
-                        paddingTop: topInset,
-                      },
-                    }}
-                  >
-                    <Stack.Screen
-                      name="index"
-                      options={{ headerShown: false, title: "Login" }}
-                    />
-                    <Stack.Screen
-                      name="(tabs)"
-                      options={{ headerShown: false, title: "SORM Symposium" }}
-                    />
-                    <Stack.Screen name="+not-found" />
-                  </Stack>
-                  <StatusBar style="auto" />
-                </SQLiteProvider>
+                {SQLiteProvider ? (
+                  <SQLiteProvider databaseName={databaseName} useSuspense>
+                    {Screens}
+                  </SQLiteProvider>
+                ) : (
+                  Screens
+                )}
               </ActiveUsersProvider>
             </AuthSessionProvider>
           </ExpoPushTokenProvider>

--- a/SORM Symposium/app/_layout.tsx
+++ b/SORM Symposium/app/_layout.tsx
@@ -17,7 +17,9 @@ import { ExpoPushTokenProvider } from "@/components/ExpoPushTokenProvider";
 import { AuthSessionProvider } from "@/components/AuthSessionProvider";
 import { sendLogMessage } from "@/services/logging";
 import { ActiveUsersProvider } from "@/components/ActiveUsersProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { openDatabaseSync, SQLiteProvider } from "expo-sqlite";
+import { asc } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/expo-sqlite";
 import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import migrations from "@/drizzle/migrations";
@@ -32,6 +34,27 @@ const DATABASE_NAME = "cache.db";
 const expo = openDatabaseSync(DATABASE_NAME);
 const db = drizzle<typeof schema>(expo);
 
+const queryClient = new QueryClient();
+
+const PREFETCH_QUERIES: Parameters<typeof queryClient.prefetchQuery>[number][] =
+  [
+    {
+      queryKey: ["contacts"],
+      queryFn: async function () {
+        const data = await db
+          .select()
+          .from(schema.contact_info)
+          .orderBy(asc(schema.contact_info.last_name));
+
+        return data.map((row) => ({
+          name: `${row.first_name} ${row.last_name}`,
+          phone: row.phone_number,
+          email: row.email,
+        }));
+      },
+    },
+  ];
+
 export default function RootLayout() {
   const initialLoad = useRef<boolean>(false);
   const colorScheme = useColorScheme() ?? "light";
@@ -41,8 +64,8 @@ export default function RootLayout() {
   const { top: topInset } = useSafeAreaInsets();
   const { success, error } = useMigrations(db, migrations);
 
-  // Send a log message on initial load to signal that a user has opened the app.
   useEffect(() => {
+    // Send a log message on initial load to signal that a user has opened the app.
     async function logInitialLoad() {
       if (initialLoad.current) {
         // If the app has already been opened, do not log again.
@@ -56,6 +79,19 @@ export default function RootLayout() {
       }
     }
 
+    // Prefetch cache from SQLite,
+    // so that it's shown immediately before useQuery is called.
+    async function prefetchCache() {
+      try {
+        await Promise.all(
+          PREFETCH_QUERIES.map((query) => queryClient.prefetchQuery(query)),
+        );
+      } catch (error) {
+        console.error("Failed to prefetch cache:", error);
+      }
+    }
+
+    prefetchCache();
     logInitialLoad();
   }, []);
 
@@ -73,35 +109,39 @@ export default function RootLayout() {
   }
 
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-        <ExpoPushTokenProvider>
-          <AuthSessionProvider>
-            <ActiveUsersProvider>
-              <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
-                <Stack
-                  screenOptions={{
-                    contentStyle: {
-                      paddingTop: topInset,
-                    },
-                  }}
-                >
-                  <Stack.Screen
-                    name="index"
-                    options={{ headerShown: false, title: "Login" }}
-                  />
-                  <Stack.Screen
-                    name="(tabs)"
-                    options={{ headerShown: false, title: "SORM Symposium" }}
-                  />
-                  <Stack.Screen name="+not-found" />
-                </Stack>
-                <StatusBar style="auto" />
-              </SQLiteProvider>
-            </ActiveUsersProvider>
-          </AuthSessionProvider>
-        </ExpoPushTokenProvider>
-      </ThemeProvider>
-    </GestureHandlerRootView>
+    <QueryClientProvider client={queryClient}>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <ThemeProvider
+          value={colorScheme === "dark" ? DarkTheme : DefaultTheme}
+        >
+          <ExpoPushTokenProvider>
+            <AuthSessionProvider>
+              <ActiveUsersProvider>
+                <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
+                  <Stack
+                    screenOptions={{
+                      contentStyle: {
+                        paddingTop: topInset,
+                      },
+                    }}
+                  >
+                    <Stack.Screen
+                      name="index"
+                      options={{ headerShown: false, title: "Login" }}
+                    />
+                    <Stack.Screen
+                      name="(tabs)"
+                      options={{ headerShown: false, title: "SORM Symposium" }}
+                    />
+                    <Stack.Screen name="+not-found" />
+                  </Stack>
+                  <StatusBar style="auto" />
+                </SQLiteProvider>
+              </ActiveUsersProvider>
+            </AuthSessionProvider>
+          </ExpoPushTokenProvider>
+        </ThemeProvider>
+      </GestureHandlerRootView>
+    </QueryClientProvider>
   );
 }

--- a/SORM Symposium/app/_layout.tsx
+++ b/SORM Symposium/app/_layout.tsx
@@ -13,15 +13,24 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { enableScreens } from "react-native-screens";
-import { Platform } from "react-native";
 import { ExpoPushTokenProvider } from "@/components/ExpoPushTokenProvider";
 import { AuthSessionProvider } from "@/components/AuthSessionProvider";
 import { sendLogMessage } from "@/services/logging";
-import { getDeviceId } from "@/lib/user";
 import { ActiveUsersProvider } from "@/components/ActiveUsersProvider";
+import { openDatabaseSync, SQLiteProvider } from "expo-sqlite";
+import { drizzle } from "drizzle-orm/expo-sqlite";
+import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
+import migrations from "@/drizzle/migrations";
+import * as schema from "@/db/schema";
 
 // Enable screens for better performance
 enableScreens();
+
+const DATABASE_NAME = "cache.db";
+
+// Open the SQLite database synchronously
+const expo = openDatabaseSync(DATABASE_NAME);
+const db = drizzle<typeof schema>(expo);
 
 export default function RootLayout() {
   const initialLoad = useRef<boolean>(false);
@@ -30,6 +39,7 @@ export default function RootLayout() {
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
   const { top: topInset } = useSafeAreaInsets();
+  const { success, error } = useMigrations(db, migrations);
 
   // Send a log message on initial load to signal that a user has opened the app.
   useEffect(() => {
@@ -49,6 +59,14 @@ export default function RootLayout() {
     logInitialLoad();
   }, []);
 
+  useEffect(() => {
+    if (success) {
+      console.log("Database migrations completed successfully.");
+    } else if (error) {
+      console.error("Database migrations failed:", error);
+    }
+  }, [success, error]);
+
   if (!loaded) {
     // Async font loading only occurs in development.
     return null;
@@ -60,18 +78,26 @@ export default function RootLayout() {
         <ExpoPushTokenProvider>
           <AuthSessionProvider>
             <ActiveUsersProvider>
-              <Stack
-                screenOptions={{
-                  contentStyle: {
-                    paddingTop: topInset,
-                  },
-                }}
-              >
-                <Stack.Screen name="index" options={{ headerShown: false, title: "Login" }} />
-                <Stack.Screen name="(tabs)" options={{ headerShown: false, title: "SORM Symposium" }} />
-                <Stack.Screen name="+not-found" />
-              </Stack>
-              <StatusBar style="auto" />
+              <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
+                <Stack
+                  screenOptions={{
+                    contentStyle: {
+                      paddingTop: topInset,
+                    },
+                  }}
+                >
+                  <Stack.Screen
+                    name="index"
+                    options={{ headerShown: false, title: "Login" }}
+                  />
+                  <Stack.Screen
+                    name="(tabs)"
+                    options={{ headerShown: false, title: "SORM Symposium" }}
+                  />
+                  <Stack.Screen name="+not-found" />
+                </Stack>
+                <StatusBar style="auto" />
+              </SQLiteProvider>
             </ActiveUsersProvider>
           </AuthSessionProvider>
         </ExpoPushTokenProvider>

--- a/SORM Symposium/babel.config.js
+++ b/SORM Symposium/babel.config.js
@@ -1,0 +1,8 @@
+/* See https://orm.drizzle.team/docs/get-started/expo-new */
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [["inline-import", { extensions: [".sql"] }]],
+  };
+};

--- a/SORM Symposium/db/index.native.ts
+++ b/SORM Symposium/db/index.native.ts
@@ -1,0 +1,15 @@
+import { openDatabaseSync, SQLiteProvider } from "expo-sqlite";
+import { drizzle } from "drizzle-orm/expo-sqlite";
+import * as schema from "@/db/schema";
+import { CacheDatabase } from ".";
+
+const DATABASE_NAME = "cache.db";
+
+export default function getCacheDatabase(): CacheDatabase {
+  const expo = openDatabaseSync(DATABASE_NAME);
+  return {
+    db: drizzle<typeof schema>(expo),
+    databaseName: DATABASE_NAME,
+    SQLiteProvider
+  };
+}

--- a/SORM Symposium/db/index.ts
+++ b/SORM Symposium/db/index.ts
@@ -1,0 +1,14 @@
+import { drizzle } from 'drizzle-orm/expo-sqlite';
+import { SQLiteProviderProps } from 'expo-sqlite';
+import { FC } from 'react';
+import * as schema from '@/db/schema';
+
+export type CacheDatabase = {
+  db: ReturnType<typeof drizzle<typeof schema>> | null;
+  databaseName: string;
+  SQLiteProvider: FC<SQLiteProviderProps> | null;
+}
+
+export default function getCacheDatabase(): CacheDatabase {
+  throw new Error("Should not be called directly.");
+}

--- a/SORM Symposium/db/index.web.ts
+++ b/SORM Symposium/db/index.web.ts
@@ -1,0 +1,9 @@
+import { CacheDatabase } from ".";
+
+export default function getCacheDatabase(): CacheDatabase {
+  return {
+    db: null, // No database instance for web
+    databaseName: "cache.db",
+    SQLiteProvider: null // No SQLiteProvider for web
+  }
+}

--- a/SORM Symposium/db/schema.ts
+++ b/SORM Symposium/db/schema.ts
@@ -1,0 +1,28 @@
+import { sql } from "drizzle-orm";
+import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * Note: Ensure to keep the tables in this file in sync with Supabase.
+ * 
+ * To perform a migration, run:
+ * `npx drizzle-kit generate`.
+ * 
+ * If this fails, try the following instead:
+ * `npm exec drizzle-kit generate`
+ */
+
+export const announcements = sqliteTable("test_announcements", {
+  id: int().primaryKey({ autoIncrement: true }),
+  created_at: int({ mode: "timestamp" }).notNull().default(sql`(CURRENT_TIMESTAMP)`),
+  body: text().notNull(),
+  title: text().notNull()
+});
+
+export const contact_info = sqliteTable("contact_info", {
+  id: int().primaryKey({ autoIncrement: true }),
+  first_name: text().notNull(),
+  last_name: text().notNull(),
+  phone_number: text().notNull(),
+  email: text().notNull(),
+  created_at: int({ mode: "timestamp" }).notNull().default(sql`(CURRENT_TIMESTAMP)`),
+})

--- a/SORM Symposium/drizzle.config.ts
+++ b/SORM Symposium/drizzle.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  driver: "expo",
+  schema: "./db/schema.ts",
+  out: "./drizzle",
+});

--- a/SORM Symposium/hooks/useCacheDatabase.ts
+++ b/SORM Symposium/hooks/useCacheDatabase.ts
@@ -1,0 +1,15 @@
+import { useSQLiteContext } from "expo-sqlite";
+import { useMemo } from "react";
+import { drizzle } from "drizzle-orm/expo-sqlite";
+import * as schema from "@/db/schema";
+
+/**
+ * A hook that returns a Drizzle Database instance for the SQLite database.
+ * @returns A Drizzle Database instance.
+ */
+function useCacheDatabase() {
+  const db = useSQLiteContext();
+  return useMemo(() => drizzle(db, { schema }), [db]);
+}
+
+export default useCacheDatabase;

--- a/SORM Symposium/hooks/useContacts.ts
+++ b/SORM Symposium/hooks/useContacts.ts
@@ -35,9 +35,6 @@ export function useContacts() {
         created_at: new Date(row.created_at), // Supabase returns created_at as a string; to store in SQLite, convert it to a Date object
       }));
 
-      // Pretend an error occurred if no data is returned
-      throw new Error("Something went wrong!");
-
       // Populate the cache with the fetched data
       await cache
         .insert(contact_info)

--- a/SORM Symposium/hooks/useContacts.ts
+++ b/SORM Symposium/hooks/useContacts.ts
@@ -1,7 +1,9 @@
 import { supabase } from "@/constants/supabase";
-import { useSQLiteContext } from "expo-sqlite";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import useCacheDatabase from "./useCacheDatabase";
+import { contact_info } from "@/db/schema";
+import { sql } from "drizzle-orm";
 
 /**
  * Hook to fetch contact info from Supabase
@@ -14,37 +16,47 @@ export type ContactInfo = {
 };
 
 export function useContacts() {
-  const [contacts, setContacts] = useState<ContactInfo[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<Error | null>(null);
   const cache = useCacheDatabase();
-  
-  const fetchContacts = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const { data, error } = await supabase
+
+  return useQuery<ContactInfo[]>({
+    queryKey: ["contacts"],
+    queryFn: async function () {
+      const { data = [], error } = await supabase
         .from("contact_info")
         .select("*")
         .order("last_name", { ascending: true });
-      if (error) throw new Error(error.message);
-      const mapped = (data || []).map(row => ({
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      const insertData = data!.map((row) => ({
+        ...row,
+        created_at: new Date(row.created_at), // Supabase returns created_at as a string; to store in SQLite, convert it to a Date object
+      }));
+
+      // Pretend an error occurred if no data is returned
+      throw new Error("Something went wrong!");
+
+      // Populate the cache with the fetched data
+      await cache
+        .insert(contact_info)
+        .values(insertData)
+        .onConflictDoUpdate({
+          target: contact_info.id,
+          set: {
+            first_name: sql.raw(`excluded.${contact_info.first_name.name}`),
+            last_name: sql.raw(`excluded.${contact_info.last_name.name}`),
+            phone_number: sql.raw(`excluded.${contact_info.phone_number.name}`),
+          },
+        });
+
+      return data!.map<ContactInfo>((row) => ({
         name: `${row.first_name} ${row.last_name}`,
         phone: row.phone_number,
         email: row.email,
       }));
-      setContacts(mapped);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error("Unknown error"));
-      setContacts([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchContacts();
-  }, [fetchContacts]);
-
-  return { contacts, loading, error, refresh: fetchContacts };
+    },
+    enabled: true,
+  });
 }

--- a/SORM Symposium/hooks/useContacts.ts
+++ b/SORM Symposium/hooks/useContacts.ts
@@ -1,5 +1,7 @@
 import { supabase } from "@/constants/supabase";
+import { useSQLiteContext } from "expo-sqlite";
 import { useCallback, useEffect, useState } from "react";
+import useCacheDatabase from "./useCacheDatabase";
 
 /**
  * Hook to fetch contact info from Supabase
@@ -15,7 +17,8 @@ export function useContacts() {
   const [contacts, setContacts] = useState<ContactInfo[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>(null);
-
+  const cache = useCacheDatabase();
+  
   const fetchContacts = useCallback(async () => {
     setLoading(true);
     setError(null);

--- a/SORM Symposium/hooks/useContacts/index.native.ts
+++ b/SORM Symposium/hooks/useContacts/index.native.ts
@@ -1,21 +1,24 @@
 import { supabase } from "@/constants/supabase";
-import { useCallback, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import useCacheDatabase from "./useCacheDatabase";
+import useCacheDatabase from "../useCacheDatabase";
 import { contact_info } from "@/db/schema";
 import { sql } from "drizzle-orm";
+
+/**
+ * This is the hook that will be used in native platforms.
+ */
 
 /**
  * Hook to fetch contact info from Supabase
  * @returns Object containing contacts, loading state, error, and a refresh function
  */
-export type ContactInfo = {
+type ContactInfo = {
   name: string;
   phone: string;
   email: string;
 };
 
-export function useContacts() {
+export default function useContacts() {
   const cache = useCacheDatabase();
 
   return useQuery<ContactInfo[]>({
@@ -27,9 +30,9 @@ export function useContacts() {
         .order("last_name", { ascending: true });
 
       if (error) {
-        throw new Error(error.message);
+        throw error;
       }
-
+      // If successfully fetched data, insert it into the cache.
       const insertData = data!.map((row) => ({
         ...row,
         created_at: new Date(row.created_at), // Supabase returns created_at as a string; to store in SQLite, convert it to a Date object
@@ -47,13 +50,11 @@ export function useContacts() {
             phone_number: sql.raw(`excluded.${contact_info.phone_number.name}`),
           },
         });
-
       return data!.map<ContactInfo>((row) => ({
         name: `${row.first_name} ${row.last_name}`,
         phone: row.phone_number,
         email: row.email,
       }));
     },
-    enabled: true,
   });
 }

--- a/SORM Symposium/hooks/useContacts/index.ts
+++ b/SORM Symposium/hooks/useContacts/index.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+export type ContactInfo = {
+  name: string;
+  phone: string;
+  email: string;
+};
+
+export default function useContacts(): ReturnType<typeof useQuery<ContactInfo[]>> {
+  throw new Error("Should not be called directly.");
+} 

--- a/SORM Symposium/hooks/useContacts/index.web.ts
+++ b/SORM Symposium/hooks/useContacts/index.web.ts
@@ -1,0 +1,34 @@
+import { supabase } from "@/constants/supabase";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Hook to fetch contact info from Supabase
+ * @returns Object containing contacts, loading state, error, and a refresh function
+ */
+type ContactInfo = {
+  name: string;
+  phone: string;
+  email: string;
+};
+
+export default function useContacts() {
+  return useQuery<ContactInfo[]>({
+    queryKey: ["contacts"],
+    queryFn: async function () {
+      const { data = [], error } = await supabase
+        .from("contact_info")
+        .select("*")
+        .order("last_name", { ascending: true });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return data!.map<ContactInfo>((row) => ({
+        name: `${row.first_name} ${row.last_name}`,
+        phone: row.phone_number,
+        email: row.email,
+      }));
+    },
+  });
+}

--- a/SORM Symposium/lib/cacheDB.ts
+++ b/SORM Symposium/lib/cacheDB.ts
@@ -1,0 +1,13 @@
+import { openDatabaseSync } from "expo-sqlite";
+import { drizzle } from "drizzle-orm/expo-sqlite";
+import { Platform } from "react-native";
+import * as schema from "@/db/schema";
+
+export function getCacheDatabase(dbName: string) {
+  if (Platform.OS === "web") {
+    return null;
+  }
+
+  const expo = openDatabaseSync(dbName);
+  return drizzle<typeof schema>(expo);
+}

--- a/SORM Symposium/metro.config.js
+++ b/SORM Symposium/metro.config.js
@@ -8,18 +8,6 @@ const config = getDefaultConfig(__dirname);
 config.resolver.unstable_enablePackageExports = false;
 
 /* for drizzle. */
-config.resolver.sourceExts.push('sql');
-
-// Add wasm asset support
-config.resolver.assetExts.push('wasm');
- 
-// Add COEP and COOP headers to support SharedArrayBuffer
-config.server.enhanceMiddleware = (middleware) => {
-  return (req, res, next) => {
-    res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
-    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-    middleware(req, res, next);
-  };
-};
+config.resolver.sourceExts.push("sql");
 
 module.exports = config;

--- a/SORM Symposium/metro.config.js
+++ b/SORM Symposium/metro.config.js
@@ -10,4 +10,16 @@ config.resolver.unstable_enablePackageExports = false;
 /* for drizzle. */
 config.resolver.sourceExts.push('sql');
 
+// Add wasm asset support
+config.resolver.assetExts.push('wasm');
+ 
+// Add COEP and COOP headers to support SharedArrayBuffer
+config.server.enhanceMiddleware = (middleware) => {
+  return (req, res, next) => {
+    res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    middleware(req, res, next);
+  };
+};
+
 module.exports = config;

--- a/SORM Symposium/metro.config.js
+++ b/SORM Symposium/metro.config.js
@@ -7,4 +7,7 @@ const config = getDefaultConfig(__dirname);
 
 config.resolver.unstable_enablePackageExports = false;
 
+/* for drizzle. */
+config.resolver.sourceExts.push('sql');
+
 module.exports = config;

--- a/SORM Symposium/package-lock.json
+++ b/SORM Symposium/package-lock.json
@@ -29,6 +29,7 @@
         "expo-notifications": "~0.31.2",
         "expo-router": "~5.0.6",
         "expo-splash-screen": "~0.30.8",
+        "expo-sqlite": "~15.2.13",
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.4",
         "expo-system-ui": "~5.0.7",
@@ -4353,6 +4354,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw=="
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -6631,6 +6637,19 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "15.2.13",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-15.2.13.tgz",
+      "integrity": "sha512-CQ++NEVhpyivpWWjgZBFYzZbLVSqCr/6WdW4p12TzMOkxYqWnmvFF61N5tdhlqu7rpQeXbXq9EDlJ0nws8RFug==",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/SORM Symposium/package.json
+++ b/SORM Symposium/package.json
@@ -18,6 +18,8 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "@supabase/supabase-js": "^2.49.8",
+    "@tanstack/react-query": "^5.81.5",
+    "babel-plugin-inline-import": "^3.0.0",
     "drizzle-orm": "^0.44.2",
     "expo": "~53.0.9",
     "expo-application": "~6.1.4",

--- a/SORM Symposium/package.json
+++ b/SORM Symposium/package.json
@@ -18,10 +18,12 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "@supabase/supabase-js": "^2.49.8",
+    "drizzle-orm": "^0.44.2",
     "expo": "~53.0.9",
     "expo-application": "~6.1.4",
     "expo-blur": "~14.1.4",
     "expo-constants": "~17.1.6",
+    "expo-crypto": "~14.1.5",
     "expo-dev-client": "~5.1.8",
     "expo-device": "~7.1.4",
     "expo-font": "~13.3.1",
@@ -31,6 +33,7 @@
     "expo-notifications": "~0.31.2",
     "expo-router": "~5.0.6",
     "expo-splash-screen": "~0.30.8",
+    "expo-sqlite": "~15.2.13",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.4",
     "expo-system-ui": "~5.0.7",
@@ -43,12 +46,12 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
-    "expo-crypto": "~14.1.5"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
+    "drizzle-kit": "^0.31.4",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "typescript": "~5.8.3"


### PR DESCRIPTION
*This is supposed to be SCA-70 not SCA-69 but I didn't see it until later*

Implements the base configurations to provide a caching mechanism to the app. For now, the contact list is cached; the announcements and events will be cached later in the other tickets.

The caching works by utilizing the [Expo SQLite Database](https://docs.expo.dev/versions/latest/sdk/sqlite/), which is really just a wrapper over SQLite itself. The database can then be interacted with by using the [Drizzle ORM](https://orm.drizzle.team/docs/connect-expo-sqlite) to allow interacting with the database much easier than writing SQL statements ourselves. When the app makes a network request to the desired resource (in this case, the contacts), it will take the returned results and insert/update the new data into the cache, then returning the new data.

The app will always make a network request, but the new thing is that this time, the cache will always be displayed first. That way, if in an event the network request fails for any reason, then the cache will be displayed.

To make this process a bit easier, I've installed [TanStack Query](https://tanstack.com/query/latest), which is a modern and trusted tool that provides advanced tooling for optimizing the process of making network requests. Making network requests works with the [`useQuery`](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) hook, which can simplify the need of having to handle race conditions, query statuses, etc. To make the caching work with TanStack Query, I [prefetched](https://tanstack.com/query/latest/docs/framework/react/guides/prefetching) the data with the cache so that the cache is available in the results of `useQuery` calls ahead of time. The prefetching is set up [here](https://github.com/sorm-conference-app/conference-app/blob/3a97a80b29d404e0adc2223a8d31f7a9082aab6d/SORM%20Symposium/app/_layout.tsx#L34-L63) and ran [here](https://github.com/sorm-conference-app/conference-app/blob/3a97a80b29d404e0adc2223a8d31f7a9082aab6d/SORM%20Symposium/app/_layout.tsx#L93-L105). To properly test whether the network requests occur, toggle the `enabled` option in the QueryOptions object passed into `useQuery`. Whoever is testing this has to do this as ExpoGo needs a network connection to work for some reason.

The last thing I want to make note of is that I had to make some rough changes in order to get the SQLite database to work. SQLite is not supported on web as browsers do not have a file system like native platforms do (SQLite databases are stored in files with the `.db` or `.sqlite` file extension).
This causes an error on web to be thrown when attempting to import anything from `expo-sqlite`. To work around this, I've had to do something where whenever we needed something to do with the database, I had to extract the logic involving the database into its own function. I then had to make copies of the function with the following file names: `index.ts`, `index.web.ts`, and `index.native.ts`. Apparently, when the app is running, the import will resolve to one of these options depending on the platform. E.g, if on web, an import of `@/db` will resolve to the function at `index.web.ts`, while on native platforms the app would receive the function at `index.native.ts`. `index.ts` won't be used, but it likely had to be required to make it work.
This approach enables it so that when on web, the functions are imported from `index.web.ts`, which should not include any imports from `expo-sqlite`, allowing the error to not occur. This approach was also recommended from the [Expo team](https://github.com/expo/expo/issues/32918#issuecomment-2477623412) as well.