### PR TITLE
Sca 74 admin change attendee email

### DIFF
--- a/SORM Symposium/components/AnnouncementForm.tsx
+++ b/SORM Symposium/components/AnnouncementForm.tsx
@@ -2,11 +2,11 @@ import { Colors } from '@/constants/Colors'
 import { supabase } from '@/constants/supabase'
 import { useColorScheme } from '@/hooks/useColorScheme'
 import React from 'react'
-import { Alert, Pressable, StyleSheet, View } from 'react-native'
+import { Pressable, StyleSheet, View } from 'react-native'
 import { ThemedText } from './ThemedText'
 import ThemedTextInput from './ThemedTextInput'
-
 import { ThemedView } from './ThemedView'
+import { showSuccessMessage, showErrorMessage } from '@/lib/alerts'
 
 /**
  * A form component for submitting announcements to the test_announcements table in Supabase.
@@ -29,7 +29,7 @@ export default function AnnouncementForm() {
    */
   async function handleSubmit() {
     if (!title.trim() || !body.trim()) {
-      Alert.alert('Error', 'Both title and body are required')
+      showErrorMessage('Both title and body are required')
       return
     }
     setLoading(true)
@@ -37,9 +37,9 @@ export default function AnnouncementForm() {
     const { error } = await supabase.from('test_announcements').insert({ title, body })
     setLoading(false)
     if (error) {
-      Alert.alert('Error', error.message)
+      showErrorMessage(error.message)
     } else {
-      Alert.alert('Success', 'Announcement posted!')
+      showSuccessMessage('Announcement posted!')
       setTitle('')
       setBody('')
     }

--- a/SORM Symposium/components/ConfirmEditEmailModal.tsx
+++ b/SORM Symposium/components/ConfirmEditEmailModal.tsx
@@ -1,0 +1,244 @@
+import React, { useState } from 'react';
+import { Modal, Pressable, StyleSheet } from 'react-native';
+import { ThemedView } from './ThemedView';
+import { ThemedText } from './ThemedText';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+interface ConfirmEditEmailModalProps {
+  visible: boolean;
+  attendeeName: string;
+  attendeeEmail: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export default function ConfirmEditEmailModal({
+  visible,
+  attendeeName,
+  attendeeEmail,
+  onCancel,
+  onConfirm
+}: ConfirmEditEmailModalProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const [stage, setStage] = useState<'first' | 'second'>('first');
+
+  const handleFirstConfirm = () => {
+    setStage('second');
+  };
+
+  const handleSecondConfirm = () => {
+    setStage('first');
+    onConfirm();
+  };
+
+  const handleCancel = () => {
+    setStage('first');
+    onCancel();
+  };
+
+  return (
+    <>
+      {/* First Stage Modal */}
+      <Modal
+        visible={visible && stage === 'first'}
+        animationType="fade"
+        transparent={true}
+        onRequestClose={handleCancel}
+      >
+        <ThemedView style={styles.overlay}>
+          <ThemedView style={[
+            styles.modalContent,
+            { backgroundColor: Colors[colorScheme].secondaryBackgroundColor }
+          ]}>
+            <ThemedText type="title" style={styles.title}>
+              Confirm Email Edit
+            </ThemedText>
+
+            <ThemedText style={styles.infoText}>
+              Change {attendeeName}'s email to "{attendeeEmail}"?
+            </ThemedText>
+            
+            <ThemedText style={styles.message}>
+              You are about to edit an attendee's email address.
+            </ThemedText>
+            <ThemedText style={styles.message}>
+              This action will affect the attendee's ability to log in to the app.
+            </ThemedText>
+            <ThemedText style={styles.message}>
+              Are you sure you want to proceed?
+            </ThemedText>
+            
+            <ThemedView style={[
+              styles.buttonContainer,
+              { backgroundColor: Colors[colorScheme].secondaryBackgroundColor }
+            ]}>
+              <Pressable
+                style={[
+                  styles.button,
+                  styles.confirmButton,
+                  { backgroundColor: Colors[colorScheme].adminButton }
+                ]}
+                onPress={handleFirstConfirm}
+              >
+                <ThemedText style={[
+                  styles.buttonText,
+                  { color: Colors[colorScheme].adminButtonText }
+                ]}>
+                  Yes, Continue
+                </ThemedText>
+              </Pressable>
+              
+              <Pressable
+                style={[
+                  styles.button,
+                  styles.cancelButton,
+                  { backgroundColor: Colors[colorScheme].tabIconDefault }
+                ]}
+                onPress={handleCancel}
+              >
+                <ThemedText style={[
+                  styles.buttonText,
+                  { color: Colors[colorScheme].adminButtonText }
+                ]}>
+                  Cancel
+                </ThemedText>
+              </Pressable>
+            </ThemedView>
+          </ThemedView>
+        </ThemedView>
+      </Modal>
+
+      {/* Second Stage Modal */}
+      <Modal
+        visible={visible && stage === 'second'}
+        animationType="fade"
+        transparent={true}
+        onRequestClose={onCancel}
+      >
+        <ThemedView style={styles.overlay}>
+          <ThemedView style={[
+            styles.modalContent,
+            { backgroundColor: Colors[colorScheme].secondaryBackgroundColor }
+          ]}>
+            <ThemedText type="title" style={styles.title}>
+              Final Confirmation
+            </ThemedText>
+
+            <ThemedText style={styles.infoText}>
+              Change {attendeeName}'s email to "{attendeeEmail}"?
+            </ThemedText>
+            
+            <ThemedText style={styles.message}>
+              This user's email address will be permanently updated in the system.
+            </ThemedText>
+            <ThemedText style={styles.message}>
+              This action cannot be undone.
+            </ThemedText>
+            <ThemedText style={styles.message}>
+              Do you want to proceed with the update?
+            </ThemedText>
+            
+            <ThemedView style={[
+              styles.buttonContainer,
+              { backgroundColor: Colors[colorScheme].secondaryBackgroundColor }
+            ]}>
+              <Pressable
+                style={[
+                  styles.button,
+                  styles.confirmButton,
+                  { backgroundColor: '#dc3545' } // Red color for final confirmation
+                ]}
+                onPress={handleSecondConfirm}
+              >
+                <ThemedText style={[
+                  styles.buttonText,
+                  { color: Colors[colorScheme].adminButtonText }
+                ]}>
+                  Yes, Update Email
+                </ThemedText>
+              </Pressable>
+              
+              <Pressable
+                style={[
+                  styles.button,
+                  styles.cancelButton,
+                  { backgroundColor: Colors[colorScheme].tabIconDefault }
+                ]}
+                onPress={handleCancel}
+              >
+                <ThemedText style={[
+                  styles.buttonText,
+                  { color: Colors[colorScheme].adminButtonText }
+                ]}>
+                  Cancel
+                </ThemedText>
+              </Pressable>
+            </ThemedView>
+          </ThemedView>
+        </ThemedView>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  modalContent: {
+    margin: 20,
+    borderRadius: 20,
+    padding: 20,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+    minWidth: 300,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  infoText: {
+    textAlign: 'center',
+    marginTop: 15,
+    marginBottom: 25,
+    lineHeight: 20,
+    fontStyle: 'italic',
+  },
+  message: {
+    textAlign: 'center',
+    marginBottom: 10,
+    lineHeight: 20,
+  },
+  buttonContainer: {
+    flexDirection: 'column',
+    gap: 10,
+    width: '100%',
+    marginTop: 10,
+  },
+  button: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  confirmButton: {
+    marginBottom: 5,
+  },
+  cancelButton: {
+    marginTop: 5,
+  },
+  buttonText: {
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+});

--- a/SORM Symposium/components/ContactEditForm.tsx
+++ b/SORM Symposium/components/ContactEditForm.tsx
@@ -9,6 +9,13 @@ import { ThemedText } from "./ThemedText";
 import ThemedTextInput from "./ThemedTextInput";
 import { ThemedView } from "./ThemedView";
 
+function handleString(str: string | null): string {
+  if (str === null) {
+    return "";
+  }
+  return str;
+}
+
 /**
  * Form for editing existing contact information in Supabase.
  * Allows selection of a contact, editing their info, and updating in the database.
@@ -17,17 +24,21 @@ import { ThemedView } from "./ThemedView";
 export default function ContactEditForm() {
   // State for all contacts
   const [contacts, setContacts] = useState<Tables<'contact_info'>[]>([]);
+  const [attendees, setAttendees] = useState<Tables<'attendee_info'>[]>([]);
   // State for selected contact id (use empty string for web compatibility)
   const [selectedId, setSelectedId] = useState<number | string>("");
   // State for form fields
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
+  const [attendeeName, setAttendeeName] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
   const [email, setEmail] = useState("");
   const [disabled, setDisabled] = useState(true);
   // Loading and error state
   const [loading, setLoading] = useState(false);
   const [fetching, setFetching] = useState(true);
+
+  const [editingAttendee, setEditingAttendee] = useState(false);
 
   // Get current color scheme for theming
   const colorScheme = useColorScheme() ?? 'light';
@@ -51,24 +62,57 @@ export default function ContactEditForm() {
     fetchContacts();
   }, []);
 
+  useEffect(() => {
+    async function fetchAttendees() {
+      const { data, error } = await supabase
+        .from("attendee_info")
+        .select("*")
+        .order("name", { ascending: true });
+      if (error) {
+        Alert.alert("Error", error.message);
+        setAttendees([]);
+      } else {
+        setAttendees(data || []);
+      }
+    }
+    fetchAttendees();
+  }, []);
+
   // When a contact is selected, always prefill the form fields
   useEffect(() => {
-    if (selectedId !== "" && typeof selectedId === "number") {
-      const contact = contacts.find(c => c.id === selectedId);
-      if (contact) {
-        setFirstName(contact.first_name);
-        setLastName(contact.last_name);
-        setPhoneNumber(contact.phone_number);
-        setEmail(contact.email);
+    if (editingAttendee) {
+      if (selectedId !== "" && typeof selectedId === "number") {
+        const attendee = attendees.find(a => a.id === selectedId);
+        if (attendee) {
+          setAttendeeName(handleString(attendee.name));
+          setEmail(handleString(attendee.email));
+        }
+      } else {
+        setAttendeeName("");
+        setEmail("");
       }
     } else {
-      // Clear fields if no contact is selected
-      setFirstName("");
-      setLastName("");
-      setPhoneNumber("");
-      setEmail("");
+      if (selectedId !== "" && typeof selectedId === "number") {
+        const contact = contacts.find(c => c.id === selectedId);
+        if (contact) {
+          setFirstName(handleString(contact.first_name));
+          setLastName(handleString(contact.last_name));
+          setPhoneNumber(handleString(contact.phone_number));
+          setEmail(handleString(contact.email));
+        }
+      } else {
+        // Clear fields if no contact is selected
+        setFirstName("");
+        setLastName("");
+        setPhoneNumber("");
+        setEmail("");
+      }
     }
-  }, [selectedId, contacts]);
+  }, [selectedId, contacts, attendees]);
+
+  useEffect(() => {
+    setSelectedId("");
+  }, [editingAttendee]);
 
   /**
    * Handle updating the selected contact in Supabase
@@ -100,6 +144,36 @@ export default function ContactEditForm() {
         .select("*")
         .order("last_name", { ascending: true });
       setContacts(data || []);
+    }
+  }
+
+  async function handleUpdateAttendee() {
+    console.log("handleUpdateAttendee: selectedId = ", selectedId);
+    console.log("handleUpdateAttendee: email = ", email);
+    if (selectedId === "" || typeof selectedId !== "number") return;
+    if (!email.trim()) {
+      Alert.alert("Error", "Email is required");
+      return;
+    }
+    setLoading(true);
+    const { error } = await supabase
+      .from("attendee_info")
+      .update({
+        email: email,
+      })
+      .eq("id", selectedId);
+    setLoading(false);
+    if (error) {
+      console.log("handleUpdateAttendee: error = ", error);
+      Alert.alert("Error", error.message);
+    } else {
+      console.log("handleUpdateAttendee: success");
+      Alert.alert("Success", "Attendee email updated");
+      const { data } = await supabase
+        .from("attendee_info")
+        .select("*")
+        .order("name", { ascending: true });
+      setAttendees(data || []);
     }
   }
 
@@ -141,10 +215,30 @@ export default function ContactEditForm() {
           style={[styles.subtitleText, { color: Colors[colorScheme].text }]} 
           type="subtitle"
         >
-          Select a contact from the list to edit their information
+          {editingAttendee 
+          ? "Select an attendee from the list to edit their email" 
+          : "Select a planning team member from the list to edit their contact information"}
         </ThemedText>
+        <View style={styles.toggleButtonContainer}>
+          <Pressable 
+            style={[
+              styles.toggleButton,
+              { backgroundColor: Colors[colorScheme].adminButton },
+              { borderColor: Colors[colorScheme].tint },
+            ]}
+            onPress={() => setEditingAttendee(!editingAttendee)}
+          >
+            <ThemedText
+              style={[
+                styles.toggleButtonText,
+                { color: Colors[colorScheme].adminButtonText },
+              ]}
+            >
+              {editingAttendee ? "Edit Planning Team Member Info" : "Edit Attendee Emails"}
+            </ThemedText>
+          </Pressable>
+        </View>
       </View>
-      
       <View style={styles.content}>
         {/* Picker for selecting a contact */}
         <View style={pickerContainerStyle}>
@@ -172,45 +266,56 @@ export default function ContactEditForm() {
             <Picker.Item 
               label="Select a contact" 
               value="select" 
-              color={colorScheme === 'dark' ? '#FFFFFF' : '#000000'}
+              color={Colors[colorScheme].text}
             />
-            {contacts.map(contact => (
+            {editingAttendee ? attendees.map(attendee => (
+              <Picker.Item
+                key={attendee.id}
+                label={handleString(attendee.name)}
+                value={attendee.id}
+                color={Colors[colorScheme].text}
+              />
+            )) : contacts.map(contact => (
               <Picker.Item
                 key={contact.id}
                 label={`${contact.first_name} ${contact.last_name}`}
                 value={contact.id}
-                color={colorScheme === 'dark' ? '#FFFFFF' : '#000000'}
+                color={Colors[colorScheme].text}
               />
             ))}
           </Picker>
         </View>
         
         {/* Form fields for editing */}
-        <ThemedTextInput
-          value={firstName}
-          onChangeText={setFirstName}
-          placeholder="First Name"
-          editable={selectedId !== "" && typeof selectedId === "number"}
-          accessibilityLabel="First name input field"
-          accessibilityHint="Enter the contact's first name"
-        />
-        <ThemedTextInput
-          value={lastName}
-          onChangeText={setLastName}
-          placeholder="Last Name"
-          editable={selectedId !== "" && typeof selectedId === "number"}
-          accessibilityLabel="Last name input field"
-          accessibilityHint="Enter the contact's last name"
-        />
-        <ThemedTextInput
-          value={phoneNumber}
-          onChangeText={setPhoneNumber}
-          placeholder="Phone Number"
-          keyboardType="phone-pad"
-          editable={selectedId !== "" && typeof selectedId === "number"}
-          accessibilityLabel="Phone number input field"
-          accessibilityHint="Enter the contact's phone number"
-        />
+        {!editingAttendee && (
+          <>
+          <ThemedTextInput
+            value={firstName}
+            onChangeText={setFirstName}
+            placeholder="First Name"
+            editable={selectedId !== "" && typeof selectedId === "number"}
+            accessibilityLabel="First name input field"
+            accessibilityHint="Enter the contact's first name"
+          />
+          <ThemedTextInput
+            value={lastName}
+            onChangeText={setLastName}
+            placeholder="Last Name"
+            editable={selectedId !== "" && typeof selectedId === "number"}
+            accessibilityLabel="Last name input field"
+            accessibilityHint="Enter the contact's last name"
+          />
+          <ThemedTextInput
+            value={phoneNumber}
+            onChangeText={setPhoneNumber}
+            placeholder="Phone Number"
+            keyboardType="phone-pad"
+            editable={selectedId !== "" && typeof selectedId === "number"}
+            accessibilityLabel="Phone number input field"
+            accessibilityHint="Enter the contact's phone number"
+          />
+        </>
+        )}
         <ThemedTextInput
           value={email}
           onChangeText={setEmail}
@@ -221,7 +326,7 @@ export default function ContactEditForm() {
           accessibilityHint="Enter the contact's email address"
         />
         <Pressable
-        onPress={handleUpdate}
+        onPress={editingAttendee ? handleUpdateAttendee : handleUpdate}
         disabled={loading || selectedId === "" || typeof selectedId !== "number"}
         style={[
           styles.updateButton,
@@ -230,15 +335,15 @@ export default function ContactEditForm() {
           { borderColor: Colors[colorScheme].adminButtonText },
           { borderWidth: 1 },
         ]}
-        accessibilityLabel="Update contact button"
-        accessibilityHint="Press to save changes to the selected contact"
+        accessibilityLabel="Update button"
+        accessibilityHint="Press to save changes to the selected information"
         accessibilityRole="button"
         accessibilityState={{ disabled: loading || selectedId === "" || typeof selectedId !== "number" }}
       >
         <ThemedText style={[styles.updateButtonText,
           { color: Colors[colorScheme].adminButtonText }
         ]}>
-          {loading ? "Updating..." : "Update Contact"}
+          {loading ? "Updating..." : editingAttendee ? "Update Attendee Email" : "Update Contact"}
         </ThemedText>
       </Pressable>
       </View>
@@ -271,5 +376,19 @@ const styles = StyleSheet.create({
   updateButtonText: {
     fontWeight: 'bold',
     fontSize: 18,
+  },
+  toggleButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  toggleButtonText: {
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  toggleButtonContainer: {
+    alignItems: 'flex-start',
+    paddingVertical: 8,
   },
 });

--- a/SORM Symposium/components/ContactEditForm.tsx
+++ b/SORM Symposium/components/ContactEditForm.tsx
@@ -8,6 +8,7 @@ import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, View } from 
 import { ThemedText } from "./ThemedText";
 import ThemedTextInput from "./ThemedTextInput";
 import { ThemedView } from "./ThemedView";
+import ConfirmEditEmailModal from "./ConfirmEditEmailModal";
 
 function handleString(str: string | null): string {
   if (str === null) {
@@ -37,8 +38,11 @@ export default function ContactEditForm() {
   // Loading and error state
   const [loading, setLoading] = useState(false);
   const [fetching, setFetching] = useState(true);
-
+  // State for editing attendee info
   const [editingAttendee, setEditingAttendee] = useState(false);
+
+  // State for showing confirm edit email modal
+  const [showConfirmEditEmailModal, setShowConfirmEditEmailModal] = useState(false);
 
   // Get current color scheme for theming
   const colorScheme = useColorScheme() ?? 'light';
@@ -138,7 +142,7 @@ export default function ContactEditForm() {
       Alert.alert("Error", error.message);
     } else {
       Alert.alert("Success", "Contact updated");
-      // Optionally refresh contacts
+      // Refresh contacts
       const { data } = await supabase
         .from("contact_info")
         .select("*")
@@ -148,8 +152,7 @@ export default function ContactEditForm() {
   }
 
   async function handleUpdateAttendee() {
-    console.log("handleUpdateAttendee: selectedId = ", selectedId);
-    console.log("handleUpdateAttendee: email = ", email);
+    setShowConfirmEditEmailModal(false);
     if (selectedId === "" || typeof selectedId !== "number") return;
     if (!email.trim()) {
       Alert.alert("Error", "Email is required");
@@ -164,11 +167,10 @@ export default function ContactEditForm() {
       .eq("id", selectedId);
     setLoading(false);
     if (error) {
-      console.log("handleUpdateAttendee: error = ", error);
       Alert.alert("Error", error.message);
     } else {
-      console.log("handleUpdateAttendee: success");
       Alert.alert("Success", "Attendee email updated");
+      // Refresh attendees
       const { data } = await supabase
         .from("attendee_info")
         .select("*")
@@ -179,7 +181,7 @@ export default function ContactEditForm() {
 
   if (fetching) {
     return (
-      <ThemedView style={styles.container}>
+      <ThemedView>
         <View style={styles.header}>
           <ThemedText type="title">Contact Editor</ThemedText>
         </View>
@@ -208,7 +210,7 @@ export default function ContactEditForm() {
   };
 
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView>
       <View style={[styles.header, { borderBottomColor: Colors[colorScheme].tint }]}>
         <ThemedText type="title">Contact Editor</ThemedText>
         <ThemedText 
@@ -326,35 +328,39 @@ export default function ContactEditForm() {
           accessibilityHint="Enter the contact's email address"
         />
         <Pressable
-        onPress={editingAttendee ? handleUpdateAttendee : handleUpdate}
-        disabled={loading || selectedId === "" || typeof selectedId !== "number"}
-        style={[
-          styles.updateButton,
-          loading || selectedId === "" || typeof selectedId !== "number" ? 
-          { backgroundColor: Colors[colorScheme].tabIconDefault } : { backgroundColor: Colors[colorScheme].adminButton },
-          { borderColor: Colors[colorScheme].adminButtonText },
-          { borderWidth: 1 },
-        ]}
-        accessibilityLabel="Update button"
-        accessibilityHint="Press to save changes to the selected information"
-        accessibilityRole="button"
-        accessibilityState={{ disabled: loading || selectedId === "" || typeof selectedId !== "number" }}
-      >
-        <ThemedText style={[styles.updateButtonText,
-          { color: Colors[colorScheme].adminButtonText }
-        ]}>
-          {loading ? "Updating..." : editingAttendee ? "Update Attendee Email" : "Update Contact"}
-        </ThemedText>
-      </Pressable>
+          onPress={editingAttendee ? () => setShowConfirmEditEmailModal(true) : handleUpdate}
+          disabled={loading || selectedId === "" || typeof selectedId !== "number"}
+          style={[
+            styles.updateButton,
+            loading || selectedId === "" || typeof selectedId !== "number" ? 
+            { backgroundColor: Colors[colorScheme].tabIconDefault } : { backgroundColor: Colors[colorScheme].adminButton },
+            { borderColor: Colors[colorScheme].adminButtonText },
+          ]}
+          accessibilityLabel="Update button"
+          accessibilityHint="Press to save changes to the selected information"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: loading || selectedId === "" || typeof selectedId !== "number" }}
+        >
+          <ThemedText style={[styles.updateButtonText,
+            { color: Colors[colorScheme].adminButtonText }
+          ]}>
+            {loading ? "Updating..." : editingAttendee ? "Update Attendee Email" : "Update Contact"}
+          </ThemedText>
+        </Pressable>
       </View>
+
+      <ConfirmEditEmailModal
+        visible={showConfirmEditEmailModal}
+        attendeeName={attendeeName}
+        attendeeEmail={email}
+        onCancel={() => setShowConfirmEditEmailModal(false)}
+        onConfirm={handleUpdateAttendee}
+      />
     </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   header: {
     padding: 16,
     borderBottomWidth: 1,
@@ -371,6 +377,7 @@ const styles = StyleSheet.create({
   updateButton: {
     padding: 10,
     borderRadius: 5,
+    borderWidth: 1,
     alignItems: 'center',
   },
   updateButtonText: {

--- a/SORM Symposium/components/ContactEditForm.tsx
+++ b/SORM Symposium/components/ContactEditForm.tsx
@@ -4,11 +4,12 @@ import { useColorScheme } from "@/hooks/useColorScheme";
 import { Tables } from "@/types/Supabase.types";
 import { Picker } from "@react-native-picker/picker";
 import { useEffect, useState } from "react";
-import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, View } from "react-native";
+import { ActivityIndicator, Platform, Pressable, StyleSheet, View } from "react-native";
 import { ThemedText } from "./ThemedText";
 import ThemedTextInput from "./ThemedTextInput";
 import { ThemedView } from "./ThemedView";
 import ConfirmEditEmailModal from "./ConfirmEditEmailModal";
+import { showSuccessMessage, showErrorMessage } from "@/lib/alerts";
 
 function handleString(str: string | null): string {
   if (str === null) {
@@ -56,7 +57,7 @@ export default function ContactEditForm() {
         .select("*")
         .order("last_name", { ascending: true });
       if (error) {
-        Alert.alert("Error", error.message);
+        showErrorMessage("Error fetching contacts: " + error.message);
         setContacts([]);
       } else {
         setContacts(data || []);
@@ -73,7 +74,7 @@ export default function ContactEditForm() {
         .select("*")
         .order("name", { ascending: true });
       if (error) {
-        Alert.alert("Error", error.message);
+        showErrorMessage("Error fetching attendees: " + error.message);
         setAttendees([]);
       } else {
         setAttendees(data || []);
@@ -124,7 +125,7 @@ export default function ContactEditForm() {
   async function handleUpdate() {
     if (selectedId === "" || typeof selectedId !== "number") return;
     if (!firstName.trim() || !lastName.trim() || !phoneNumber.trim() || !email.trim()) {
-      Alert.alert("Error", "All fields are required");
+      showErrorMessage("All fields are required");
       return;
     }
     setLoading(true);
@@ -139,9 +140,9 @@ export default function ContactEditForm() {
       .eq("id", selectedId);
     setLoading(false);
     if (error) {
-      Alert.alert("Error", error.message);
+      showErrorMessage("Error updating contact information: " + error.message);
     } else {
-      Alert.alert("Success", "Contact updated");
+      showSuccessMessage("Contact information successfully updated");
       // Refresh contacts
       const { data } = await supabase
         .from("contact_info")
@@ -155,7 +156,7 @@ export default function ContactEditForm() {
     setShowConfirmEditEmailModal(false);
     if (selectedId === "" || typeof selectedId !== "number") return;
     if (!email.trim()) {
-      Alert.alert("Error", "Email is required");
+      showErrorMessage("Email is required");
       return;
     }
     setLoading(true);
@@ -167,9 +168,9 @@ export default function ContactEditForm() {
       .eq("id", selectedId);
     setLoading(false);
     if (error) {
-      Alert.alert("Error", error.message);
+      showErrorMessage("Error updating attendee email: " + error.message);
     } else {
-      Alert.alert("Success", "Attendee email updated");
+      showSuccessMessage("Attendee email successfully updated");
       // Refresh attendees
       const { data } = await supabase
         .from("attendee_info")

--- a/SORM Symposium/lib/alerts.ts
+++ b/SORM Symposium/lib/alerts.ts
@@ -1,0 +1,80 @@
+import { Alert, Platform } from 'react-native';
+
+/**
+ * Shows a success message using platform-specific methods
+ * @param message - The success message to display
+ */
+export function showSuccessMessage(message: string) {
+  if (Platform.OS === 'web') {
+    // For web, use a simple window.alert
+    window.alert(message);
+  } else {
+    // For mobile, use the native Alert component
+    Alert.alert("Success", message);
+  }
+}
+
+/**
+ * Shows an error message using platform-specific methods
+ * @param message - The error message to display
+ */
+export function showErrorMessage(message: string) {
+  if (Platform.OS === 'web') {
+    // For web, use a simple window.alert
+    window.alert(message);
+  } else {
+    // For mobile, use the native Alert component
+    Alert.alert("Error", message);
+  }
+}
+
+/**
+ * Shows a general message using platform-specific methods
+ * @param message - The message to display
+ */
+export function showMessage(message: string) {
+  if (Platform.OS === 'web') {
+    // For web, use a simple window.alert
+    window.alert(message);
+  } else {
+    // For mobile, use the native Alert component
+    Alert.alert("Message", message);
+  }
+}
+
+/**
+ * Shows a confirmation dialog with custom buttons
+ * @param title - The title of the dialog
+ * @param message - The message to display
+ * @param buttons - Array of button configurations
+ * @param options - Additional options for the alert
+ */
+export function showConfirmation(
+  title: string,
+  message: string,
+  buttons: Array<{
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+  }>,
+  options?: {
+    cancelable?: boolean;
+  }
+) {
+  if (Platform.OS === 'web') {
+    // For web, use a simple confirm dialog
+    const result = window.confirm(`${title}\n\n${message}`);
+    if (result) {
+      // Find the first non-cancel button and call its onPress
+      const confirmButton = buttons.find(btn => btn.style !== 'cancel');
+      confirmButton?.onPress?.();
+    } else {
+      // Find the cancel button and call its onPress
+      const cancelButton = buttons.find(btn => btn.style === 'cancel');
+      cancelButton?.onPress?.();
+    }
+  } else {
+    // For mobile, use the native Alert component
+    Alert.alert(title, message, buttons, options);
+  }
+} 


### PR DESCRIPTION
Admins can no change attendee emails from the Contact Editor. There is a button to switch between changing planning team member contact info and changing attendee emails. UI and form fields change appropriately. There are two confirmation modals that the admin must go through to make the update go through, with warnings about the change affecting the attendee's ability to log in and the change being permanent. 